### PR TITLE
[Votalog]ゲストログイン機能を実装

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -10,3 +10,7 @@
   height: 54px;
   object-fit: cover;
 }
+
+.firstview-signup-btn, .firstview-signin-btn {
+  width: 256px;
+}

--- a/app/controllers/users/registraions_controller.rb
+++ b/app/controllers/users/registraions_controller.rb
@@ -1,0 +1,9 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :ensure_normal_user, only: [:update, :destroy]
+
+  def ensure_normal_user
+    if resource.email == 'guest@example.com'
+      redirect_to root_path, alert: 'ゲストユーザー情報の編集・削除はできません。'
+    end
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,7 @@
+class Users::SessionsController < Devise::SessionsController
+  def guest_sign_in
+    user = User.find_or_create_guest_user
+    sign_in user
+    redirect_to root_path, notice: 'ゲストユーザーとしてログインしました。'
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,11 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :name, presence: true
+
+  def self.find_or_create_guest_user
+    find_or_create_by!(email: 'guest@example.com') do |user|
+      user.password = SecureRandom.urlsafe_base64
+      user.name = "ゲストユーザー"
+    end
+  end
 end

--- a/app/views/shared/_firstview.html.erb
+++ b/app/views/shared/_firstview.html.erb
@@ -5,14 +5,22 @@
         <div class="text-center">
           <h1 class="display-sm-4 display-lg-3 mb-3">Votalog</h1>
           <p class="u-letter-spacing-sm mb-4">「この前いつ水やりしたっけ？」「この株いつ頃植え替えればいいんだっけ？」がなくなる多肉植物管理ツールVotalog(ボタログ)。</p>
-          <%= link_to new_user_registration_path, class: "btn btn-secondary" do %>
-            新規登録はこちら
-            <i class="fas fa-arrow-alt-circle-right ml-2"></i>
-          <% end %>
-          <%= link_to new_user_session_path, class: "btn btn-outline-primary" do %>
-            ログインはこちら
-            <i class="fas fa-arrow-alt-circle-right ml-2"></i>
-          <% end %>
+          <div class="btn_for_signup mb-3">
+            <%= link_to new_user_registration_path, class: "btn btn-secondary firstview-signup-btn" do %>
+              新規登録はこちら
+              <i class="fas fa-arrow-alt-circle-right"></i>
+            <% end %>
+          </div>
+          <div class="btns_for_signin">
+            <%= link_to new_user_session_path, class: "btn btn-primary firstview-signin-btn" do %>
+              ログインはこちら
+              <i class="fas fa-arrow-alt-circle-right"></i>
+            <% end %>
+            <%= link_to users_guest_sign_in_path, class: "btn btn-primary firstview-signin-btn" do %>
+              ゲストログインはこちら
+              <i class="fas fa-arrow-alt-circle-right"></i>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/shared/_firstview.html.erb
+++ b/app/views/shared/_firstview.html.erb
@@ -5,13 +5,13 @@
         <div class="text-center">
           <h1 class="display-sm-4 display-lg-3 mb-3">Votalog</h1>
           <p class="u-letter-spacing-sm mb-4">「この前いつ水やりしたっけ？」「この株いつ頃植え替えればいいんだっけ？」がなくなる多肉植物管理ツールVotalog(ボタログ)。</p>
-          <div class="btn_for_signup mb-3">
+          <div class="btn-for-signup mb-3">
             <%= link_to new_user_registration_path, class: "btn btn-secondary firstview-signup-btn" do %>
               新規登録はこちら
               <i class="fas fa-arrow-alt-circle-right"></i>
             <% end %>
           </div>
-          <div class="btns_for_signin">
+          <div class="btns-for-signin">
             <%= link_to new_user_session_path, class: "btn btn-primary firstview-signin-btn" do %>
               ログインはこちら
               <i class="fas fa-arrow-alt-circle-right"></i>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -35,7 +35,7 @@
               <%= link_to "新規登録", new_user_registration_path, class: "nav-link" %>
             </li>
             <li class="nav-item mr-4 mb-2 mb-lg-0">
-              <a class="nav-link" href="contacts.html">ゲストログイン</a>
+              <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "nav-link" %>
             </li>
           </ul>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
   devise_scope :user do
     post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
+  devise_scope :user do
+    post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in'
+  end
   root 'home#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
概要
- ファーストビューにゲストログインボタンを追加
  - スタイルを適用済み
- 未ログイン時のナビゲーションバーまたはファーストビューの「ゲストログイン」ボタンを押下すると「ゲストユーザー」としてログイン
- ゲストユーザーはアカウント情報の編集と削除は行えないよう設定
  - 複数人がゲストログイン機能を利用している状態で、一方のアカウント削除等の操作が他方に影響するのを防ぐため