### PR TITLE
[Votalog]アカウント情報確認機能を実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,5 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find(current_user.id)
+  end
+end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,7 +21,7 @@
                 <i class="fas fa-angle-down small ml-1"></i>
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                <%= link_to "アカウント", "#", class: "dropdown-item" %>
+                <%= link_to "アカウント", users_account_path, class: "dropdown-item" %>
                 <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
               </div>
             </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,41 @@
+<section class="u-content-space">
+  <div class="container">
+    <header class="w-md50 mx-auto text-center mb-6">
+      <h2>アカウント情報</h2>
+    </header>
+    <div class="row mb-2">
+      <div class="col-md-6">
+        <p class="text-center mb-0">ユーザー名</p>
+      </div>
+      <div class="col-md-6">
+        <p class="text-center mb-0">
+          <%= @user.name %>
+        </p>
+      </div>
+    </div>
+    <hr class="mb-3">
+    <div class="row mb-2">
+      <div class="col-md-6">
+        <p class="text-center mb-0">メールアドレス</p>
+      </div>
+      <div class="col-md-6">
+        <p class="text-center mb-0">
+          <%= @user.email %>
+        </p>
+      </div>
+    </div>
+    <hr class="mb-3">
+    <div class="row mb-2">
+      <div class="col-md-6">
+        <p class="text-center mb-0">パスワード</p>
+      </div>
+      <div class="col-md-6">
+        <p class="text-center mb-0">******</p>
+      </div>
+    </div>
+    <hr class="mb-6">
+    <div class="text-center mb-2">
+      <%= link_to "登録情報の変更", edit_user_registration_path, class: "btn btn-outline-secondary" %>
+    </div>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
     post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in'
   end
   root 'home#index'
+  get 'users/account', to: 'users#show'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
概要
- ログインしているときのナビゲーションバーに表示される「アカウント」ボタンを押下すると下記アカウント情報が確認できる
  - 自身のユーザー名
  - 自身のメールアドレス
  - 自身のパスワード
    - セキュリティ的観点からパスワードそのものを確認することはできない仕様とした
  - アカウント情報ページからアカウント情報更新ページへの動線を用意