### PR TITLE
[Votalog]アカウント情報編集・削除機能を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,5 +5,6 @@ class ApplicationController < ActionController::Base
 
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name])
     end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,9 +1,73 @@
+# frozen_string_literal: true
+
 class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
   before_action :ensure_normal_user, only: [:update, :destroy]
 
   def ensure_normal_user
     if resource.email == 'guest@example.com'
       redirect_to root_path, alert: 'ゲストユーザー情報の編集・削除はできません。'
     end
+  end
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  def after_update_path_for(resource)
+    users_account_path
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,7 +1,33 @@
+# frozen_string_literal: true
+
 class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
   def guest_sign_in
     user = User.find_or_create_guest_user
     sign_in user
     redirect_to root_path, notice: 'ゲストユーザーとしてログインしました。'
   end
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,49 @@
+<section class="u-content-space">
+  <div class="container">
+    <header class="w-md50 mx-auto text-center mb-6">
+      <h2>アカウント情報編集</h2>
+    </header>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <div class="form-group mb-4">
+        <%= f.label :name, class: "u-font-size-90" %>
+        <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_name", resource: f.object %>
+      </div>
+
+      <div class="form-group mb-4">
+        <%= f.label :email, class: "u-font-size-90" %>
+        <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_email", resource: f.object %>
+      </div>
+
+      <div class="form-group mb-4">
+        <%= f.label :password, class: "u-font-size-90" %>
+        <span class="u-font-size-90">(変更したい場合)</span>
+        <% if @minimum_password_length %>
+          <span class="u-font-size-90">
+            ※<%= @minimum_password_length %>文字以上
+          </span>
+        <% end %>
+        <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_password", resource: f.object %>
+      </div>
+
+      <div class="form-group mb-4">
+        <%= f.label :password_confirmation, class: "u-font-size-90" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_password_confirmation", resource: f.object %>
+      </div>
+
+      <div class="form-group mb-6">
+        <%= f.label :current_password, class: "u-font-size-90" %> <span class="u-font-size-90">(変更には現在のパスワードが必要です)</span>
+        <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_current_password", resource: f.object %>
+      </div>
+
+      <div class="text-center mb-6">
+        <%= f.submit "変更を保存", class: "btn btn-secondary btn-lg" %>
+        <%= link_to "キャンセル", users_account_path, class: "btn btn-outline-secondary btn-lg" %>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,21 +7,13 @@
       <div class="form-group mb-4">
         <%= f.label :name, "ユーザー名", class: "u-font-size-90 required-column" %>
         <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
-        <% if f.object.errors.include?(:name) %>
-          <div class="invalid-input">
-            <%= f.object.errors.full_messages_for(:name).first %>
-          </div>
-        <% end %>
+        <%= render "shared/error_messages/invalid_name", resource: f.object %>
       </div>
 
       <div class="form-group mb-4">
         <%= f.label :email, "メールアドレス", class: "u-font-size-90 required-column" %>
         <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
-        <% if f.object.errors.include?(:email) %>
-          <div class="invalid-input">
-            <%= f.object.errors.full_messages_for(:email).first %>
-          </div>
-        <% end %>
+        <%= render "shared/error_messages/invalid_email", resource: f.object %>
       </div>
 
       <div class="form-group mb-4">
@@ -32,21 +24,13 @@
           </span>
         <% end %>
         <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
-        <% if f.object.errors.include?(:password) %>
-          <div class="invalid-input">
-            <%= f.object.errors.full_messages_for(:password).first %>
-          </div>
-        <% end %>
+        <%= render "shared/error_messages/invalid_password", resource: f.object %>
       </div>
 
       <div class="form-group mb-6">
         <%= f.label :password_confirmation, "パスワード（確認用）", class: "u-font-size-90 required-column" %>
         <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
-        <% if f.object.errors.include?(:password_confirmation) %>
-          <div class="invalid-input">
-            <%= f.object.errors.full_messages_for(:password_confirmation).first %>
-          </div>
-        <% end %>
+        <%= render "shared/error_messages/invalid_password_confirmation", resource: f.object %>
       </div>
 
       <div class="text-center mb-6">

--- a/app/views/shared/error_messages/_invalid_current_password.html.erb
+++ b/app/views/shared/error_messages/_invalid_current_password.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:current_password) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:current_password).first %>
+  </div>
+<% end %>

--- a/app/views/shared/error_messages/_invalid_email.html.erb
+++ b/app/views/shared/error_messages/_invalid_email.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:email) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:email).first %>
+  </div>
+<% end %>

--- a/app/views/shared/error_messages/_invalid_name.html.erb
+++ b/app/views/shared/error_messages/_invalid_name.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:name) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:name).first %>
+  </div>
+<% end %>

--- a/app/views/shared/error_messages/_invalid_password.html.erb
+++ b/app/views/shared/error_messages/_invalid_password.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:password) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:password).first %>
+  </div>
+<% end %>

--- a/app/views/shared/error_messages/_invalid_password_confirmation.html.erb
+++ b/app/views/shared/error_messages/_invalid_password_confirmation.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:password_confirmation) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:password_confirmation).first %>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -42,16 +42,3 @@
     </div>
   </div>
 </section>
-
-<%
-=begin%>
- <h3>Cancel my account</h3> 
-<%
-=end%>
-
-<%
-=begin%>
- <div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div> 
-<%
-=end%>
-

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,8 +34,24 @@
       </div>
     </div>
     <hr class="mb-6">
-    <div class="text-center mb-2">
+    <div class="text-center mb-4">
       <%= link_to "登録情報の変更", edit_user_registration_path, class: "btn btn-outline-secondary" %>
+    </div>
+    <div class="text-center mb-2">
+      <%= link_to "このアカウントを削除する(退会)", user_registration_path, method: :delete, data: { confirm: "本当にこのアカウントを削除してよろしいですか？"}, class: "btn btn-outline-danger" %>
     </div>
   </div>
 </section>
+
+<%
+=begin%>
+ <h3>Cancel my account</h3> 
+<%
+=end%>
+
+<%
+=begin%>
+ <div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div> 
+<%
+=end%>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: 'users/registrations'
+    registrations: 'users/registrations',
+    sessions: 'users/sessions'
   }
   devise_scope :user do
     post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in'


### PR DESCRIPTION
概要
- アカウント編集時に`name`カラムのupdateを許可するようストロングパラメータの設定を変更
- アカウント情報編集画面をカスタマイズ
  - バリデーションエラーが発生した場合、個別の入力欄の下にエラーメッセージを表示
  - 下記項目のユーザー情報を編集できるように設定
    - ユーザー名
    - メールアドレス
    - パスワード
- アカウント情報削除ボタンをアカウント情報確認画面に用意
  - 今回はストレージ容量を圧迫しにくい物理削除を選択し実装しました