### PR TITLE
[Votalog] 個別株登録機能を実装

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,5 @@
 class HomeController < ApplicationController
   def index
+    @user = current_user
   end
 end

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -1,4 +1,6 @@
 class PlantsController < ApplicationController
+  before_action :authenticate_user!
+
   def new
   end
 

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -17,6 +17,7 @@ class PlantsController < ApplicationController
   end
 
   def show
+    @user = current_user
   end
 
   def update

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -2,9 +2,18 @@ class PlantsController < ApplicationController
   before_action :authenticate_user!
 
   def new
+    @plant = Plant.new
   end
 
   def create
+    @plant = Plant.new(plant_params)
+    @plant.user = current_user
+    if @plant.save
+      redirect_to plant_path(@plant), notice: "#{@plant.name}をマイ多肉棚に追加しました"
+    else
+      flash.now[:alert] = '新しい株の登録に失敗しました'
+      render "new"
+    end
   end
 
   def show
@@ -14,5 +23,9 @@ class PlantsController < ApplicationController
   end
 
   def destroy
+  end
+
+  def plant_params
+    params.require(:plant).permit(:name, :next_water_day, :next_fertilizer_day, :next_replant_day, :image)
   end
 end

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -1,0 +1,16 @@
+class PlantsController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+
+  def show
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+end

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -1,0 +1,7 @@
+class Plant < ApplicationRecord
+  validates :name, presence: true
+
+  belongs_to :user
+
+  has_one_attached :image
+end

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -1,7 +1,17 @@
 class Plant < ApplicationRecord
   validates :name, presence: true
+  validate :is_file_type_valid?
 
   belongs_to :user
 
   has_one_attached :image
+
+  def is_file_type_valid?
+    return unless image.attached?
+
+    valid_file_types = ["image/png", "image/jpg", "image/gif"]
+    unless valid_file_types.include?(image.blob.content_type)
+      errors.add(:image, "には拡張子が.png, .jpg, .gifのいずれかのファイルを添付してください")
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   validates :name, presence: true
 
+  has_many :plants, dependent: :destroy
+
   def self.find_or_create_guest_user
     find_or_create_by!(email: 'guest@example.com') do |user|
       user.password = SecureRandom.urlsafe_base64

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,5 @@
 <% if user_signed_in? %>
-  <p>ログイン後のトップページ</p>
+  <%= render  "shared/my_shelf", resources: @user.plants %>
 <% else %>
   <%= render "shared/firstview" %>
   <%= render "shared/about" %>

--- a/app/views/plants/new.html.erb
+++ b/app/views/plants/new.html.erb
@@ -1,0 +1,25 @@
+<section class="u-content-space">
+  <div class="container">
+    <header  class="w-md50 mx-auto text-center mb-6">
+      <h2>新規株登録</h2>
+    </header>
+    <%= form_with model: @plant do |f| %>
+      <div class="form-group mb-4">
+        <%= f.label :name, class: "u-font-size-90 required-column" %>
+        <%= f.text_field :name, autofocus: true, placeholder: "H.obutusa x H.venusta", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_name", resource: f.object %>
+      </div>
+      <div class="form-group mb-6">
+        <%= f.label :image, class: "u-font-size-90" %>
+        <%= f.file_field :image, class: "form-control" %>
+        <%= render "shared/error_messages/invalid_image", resource: f.object %>
+      </div>
+      <div class="text-center mb-3">
+        <%= f.submit "マイ多肉棚に追加", class: "btn btn-secondary btn-lg" %>
+      </div>
+      <div class="text-center mb-2">
+        <%= link_to "キャンセル", :back, class: "btn btn-outline-secondary btn-lg" %>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -1,0 +1,1 @@
+<%= render  "shared/my_shelf", resources: @user.plants %>

--- a/app/views/shared/_my_shelf.html.erb
+++ b/app/views/shared/_my_shelf.html.erb
@@ -1,0 +1,24 @@
+<section class="u-content-space">
+  <div class="container">
+    <header class="w-md50 mx-auto mb-2">
+      <h4>マイ多肉棚</h4>
+    </header>
+    <div class="mb-6 text-right">
+      <%= link_to new_plant_path, class: "btn btn-outline-info" do %>
+        新しい株を追加する<i class="fas fa-plus-circle ml-2"></i>
+      <% end %>
+    </div>
+    <div class="row mb-2">
+      <div class="col-lg-4 col-md-6 text-center">
+        <%= link_to "ALL", root_path, class: "btn btn-outline-secondary" %>
+      </div>
+      <% resources.each do |resource| %>
+        <div class="col-lg-4 col-md-6 text-center">
+          <%= link_to plant_path(resource), class: "btn btn-outline-secondary" do %>
+            <%= resource.name %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/app/views/shared/error_messages/_invalid_image.html.erb
+++ b/app/views/shared/error_messages/_invalid_image.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:image) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:image).first %>
+  </div>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,13 @@ ja:
         password: パスワード
         password_confirmation: パスワード（確認用）
         current_password: 現在のパスワード
+      plant:
+        name: 株名称
+        next_water_day: 次の水やり予定日
+        next_fertilizer_day: 次の肥料/栄養剤散布予定日
+        next_replant_day: 次の植替え予定日
+        image: 株画像
     models:
       user: ユーザー
+      plant: 株
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,6 @@ Rails.application.routes.draw do
   end
   root 'home#index'
   get 'users/account', to: 'users#show'
+  resources :plants, except: [:index, :edit]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20231209090049_create_plants.rb
+++ b/db/migrate/20231209090049_create_plants.rb
@@ -1,0 +1,13 @@
+class CreatePlants < ActiveRecord::Migration[6.1]
+  def change
+    create_table :plants do |t|
+      t.string :name, null: false
+      t.date :next_water_day
+      t.date :next_fertilizer_day
+      t.date :next_replant_day
+      t.integer :user_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231209091221_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20231209091221_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,45 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_04_161213) do
+ActiveRecord::Schema.define(version: 2023_12_09_091221) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "plants", force: :cascade do |t|
+    t.string "name", null: false
+    t.date "next_water_day"
+    t.date "next_fertilizer_day"
+    t.date "next_replant_day"
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -25,4 +63,6 @@ ActiveRecord::Schema.define(version: 2023_12_04_161213) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
概要
- Plantモデルを生成
  - Userモデルとのリレーションを設定済み
  - `active_storage`を利用して`image`カラムに株のイメージ画像を1枚アタッチできるように設定
    - 画像ファイルは`.png`, `.jpg`, `.gif`の拡張子がついたファイルのみアップロードできるようバリデーションを設定
  - 各カラムの日本語表記設定ファイルを追加
- 必要なルーティングとコントローラをまとめて設定済み
  - 株の作成/削除、更新機能はログイン時のみ利用できるように`before_action`で制御
- ログイン時のトップページまたは各株の個別ページの「マイ多肉棚」から新しい株を追加できるよう動線を用意
- 下記の内容で新規株登録ができる機能を用意
  - 株名称（必須入力項目）
  - 株画像（任意）