### PR TITLE
[Votalog] ログ新規作成機能を実装

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,4 +1,6 @@
 class LogsController < ApplicationController
+  before_action :authenticate_user!
+
   def new
     @log = Log.new
   end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,8 +1,17 @@
 class LogsController < ApplicationController
   def new
+    @log = Log.new
   end
 
   def create
+    @log = Log.new(log_params)
+    @log.user = current_user
+    if @log.save
+      redirect_to log_path(@log), notice: "新しいログを保存しました"
+    else
+      flash.now[:alert] = "新しいログの保存に失敗しました"
+      render "new"
+    end
   end
 
   def show
@@ -15,5 +24,9 @@ class LogsController < ApplicationController
   end
 
   def destroy
+  end
+
+  def log_params
+    params.require(:log).permit(:start_time, :is_watered, :is_fertilized, :is_replanted, :memo, :image, :temperature, :humidity, :light_start_at, :light_end_at, :plant_id)
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,0 +1,19 @@
+class LogsController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,8 +1,8 @@
 class Log < ApplicationRecord
   validates :start_time, presence: true
   validates :memo, length: { maximum: 300 }
-  validates :temperature, numericality: true
-  validates :humidity, numericality: { in: 0..100 }
+  validates :temperature, numericality: true, allow_nil: true
+  validates :humidity, numericality: { in: 0..100 }, allow_nil: true
   validate :is_file_type_valid?
   validate :is_light_end_at_after_light_start_at?
 

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,0 +1,19 @@
+class Log < ApplicationRecord
+  validates :start_time, presence: true
+  validates :memo, length: { maximum: 300 }
+  validates :temperature, numericality: true
+  validates :humidity, numericality: { in: 0..100 }
+  validates :light_end_at, comparison: { greater_than: :light_start_at, message: "植物育成ライト消灯時刻は点灯時刻よりも後の時刻を入力してください" }
+  validate :is_file_type_valid?
+
+  has_one_attached :image
+
+  def is_file_type_valid?
+    return unless image.attached?
+
+    valid_file_types = ["image/png", "image/jpg", "image/gif"]
+    unless valid_file_types.include?(image.blob.content_type)
+      errors.add(:image, "には拡張子が.png, .jpg, .gifのいずれかのファイルを添付してください")
+    end
+  end
+end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -3,8 +3,8 @@ class Log < ApplicationRecord
   validates :memo, length: { maximum: 300 }
   validates :temperature, numericality: true
   validates :humidity, numericality: { in: 0..100 }
-  validates :light_end_at, comparison: { greater_than: :light_start_at, message: "植物育成ライト消灯時刻は点灯時刻よりも後の時刻を入力してください" }
   validate :is_file_type_valid?
+  validate :is_light_end_at_after_light_start_at?
 
   belongs_to :user
   belongs_to :plant
@@ -17,6 +17,12 @@ class Log < ApplicationRecord
     valid_file_types = ["image/png", "image/jpg", "image/gif"]
     unless valid_file_types.include?(image.blob.content_type)
       errors.add(:image, "には拡張子が.png, .jpg, .gifのいずれかのファイルを添付してください")
+    end
+  end
+
+  def is_light_end_at_after_light_start_at?
+    if light_end_at.present? && light_end_at < light_start_at
+      errors.add(:light_end_at, "は点灯時刻よりも後の時刻を入力してください")
     end
   end
 end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -6,6 +6,9 @@ class Log < ApplicationRecord
   validates :light_end_at, comparison: { greater_than: :light_start_at, message: "植物育成ライト消灯時刻は点灯時刻よりも後の時刻を入力してください" }
   validate :is_file_type_valid?
 
+  belongs_to :user
+  belongs_to :plant
+
   has_one_attached :image
 
   def is_file_type_valid?

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -6,6 +6,7 @@ class Plant < ApplicationRecord
   validate :is_next_replant_day_after_today?
 
   belongs_to :user
+  has_many :logs, dependent: :destroy
 
   has_one_attached :image
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   validates :name, presence: true
 
   has_many :plants, dependent: :destroy
+  has_many :logs, dependent: :destroy
 
   def self.find_or_create_guest_user
     find_or_create_by!(email: 'guest@example.com') do |user|

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -1,0 +1,83 @@
+<section class="u-content-space">
+  <div class="container">
+    <header class="w-md50 mx-auto text-center mb-6">
+      <h2>新規ログ追加</h2>
+    </header>
+    <%= form_with model: @log do |f| %>
+      <div class="form-group mb-4">
+        <%= f.label :start_time, class: "u-font-size-90 required-column" %>
+        <%= f.datetime_field :start_time, autofocus: true, class: "form-control" %>
+        <%= render "shared/error_messages/invalid_start_time", resource: f.object %>
+      </div>
+      <div class="form-group mb-4">
+        <%= f.label :plant_id, class: "u-font-size-90 required-column" %>
+        <%= f.collection_select :plant_id, current_user.plants, :id, :name, { include_blank: "選択してください" }, { class: "form-control" } %>
+        <%= render "shared/error_messages/invalid_plant_id", resource: f.object %>
+      </div>
+      <div class="row pl-3">
+        <p class="u-font-size-90 mb-2">お世話内容</p>
+      </div>
+      <div class="row mb-4">
+        <div class="col-md-4 text-center">
+          <div class="custom-control custom-checkbox">
+            <%= f.check_box :is_watered, class: "custom-control-input" %>
+            <%= f.label :is_watered, class: "custom-control-label" %>
+          </div>
+        </div>
+        <div class="col-md-4 text-center">
+          <div class="custom-control custom-checkbox">
+            <%= f.check_box :is_fertilized, class: "custom-control-input" %>
+            <%= f.label :is_fertilized, class: "custom-control-label" %>
+          </div>
+        </div>
+        <div class="col-md-4 text-center">
+          <div class="custom-control custom-checkbox">
+            <%= f.check_box :is_replanted, class: "custom-control-input" %>
+            <%= f.label :is_replanted, class: "custom-control-label" %>
+          </div>
+        </div>
+      </div>
+      <div class="form-group mb-4">
+        <%= f.label :memo, class: "u-font-size-90" %>
+        <%= f.text_area :memo, placeholder: "メモ", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_memo", resource: f.object %>
+      </div>
+      <div class="form-group mb-4">
+        <%= f.label :temperature, class: "u-font-size-90" %>
+        <%= f.number_field :temperature, step: "0.1", placeholder: "12.3", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_temperature", resource: f.object %>
+      </div>
+      <div class="form-group mb-4">
+        <%= f.label :humidity, class: "u-font-size-90" %>
+        <%= f.number_field :humidity, step: "0.1", placeholder: "65.4", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_humidity", resource: f.object %>
+      </div>
+      <div class="row">
+        <div class="col-md-6">
+          <div class="form-group mb-4">
+            <%= f.label :light_start_at, class: "u-font-size-90" %>
+            <%= f.datetime_field :light_start_at, class: "form-control" %>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="form-group mb-4">
+            <%= f.label :light_end_at, class: "u-font-size-90" %>
+            <%= f.datetime_field :light_end_at, class: "form-control" %>
+            <%= render "shared/error_messages/invalid_light_end_at", resource: f.object %>
+          </div>
+        </div>
+      </div>
+      <div class="form-group mb-6">
+        <%= f.label :image, class: "u-font-size-90" %>
+        <%= f.file_field :image, class: "form-control" %>
+        <%= render "shared/error_messages/invalid_image", resource: f.object %>
+      </div>
+      <div class="text-center mb-3">
+        <%= f.submit "ログを追加", class: "btn btn-secondary btn-lg" %>
+      </div>
+      <div class="text-center mb-2">
+        <%= link_to "キャンセル", :back, class: "btn btn-outline-secondary btn-lg" %>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -8,7 +8,7 @@
         <% end %>
       </div>
     </header>
-    <div class="row mb-2">
+    <div class="row mb-6">
       <div class="col-md-4 text-center bg-light p-3">
         <p>次回水やり予定日</p>
         <hr class="mb-6">
@@ -36,13 +36,16 @@
         </div>
       </div>
     </div>
-    <div class="d-flex justify-content-around p-6">
+    <div class="d-flex justify-content-around p-4">
       <div class="text-center">
         <%= link_to "株情報の編集", edit_plant_path(@plant), class: "btn btn-outline-secondary" %>
       </div>
       <div class="text-center">
         <%= link_to "この株を削除", plant_path(@plant), method: :delete, data: { confirm: "#{@plant.name}を削除してよろしいですか？この操作は取り消せません" }, class: "btn btn-outline-danger" %>
       </div>
+    </div>
+    <div class="text-center">
+      <%= link_to "新規ログを追加", new_log_path, class: "btn btn-secondary" %>
     </div>
   </div>
 </section>

--- a/app/views/shared/error_messages/_invalid_humidity.html.erb
+++ b/app/views/shared/error_messages/_invalid_humidity.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:humidity) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:humidity).first %>
+  </div>
+<% end %>

--- a/app/views/shared/error_messages/_invalid_light_end_at.html.erb
+++ b/app/views/shared/error_messages/_invalid_light_end_at.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:light_end_at) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:light_end_at).first %>
+  </div>
+<% end %>

--- a/app/views/shared/error_messages/_invalid_memo.html.erb
+++ b/app/views/shared/error_messages/_invalid_memo.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:memo) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:memo).first %>
+  </div>
+<% end %>

--- a/app/views/shared/error_messages/_invalid_plant_id.html.erb
+++ b/app/views/shared/error_messages/_invalid_plant_id.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:plant) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:plant).first %>
+  </div>
+<% end %>

--- a/app/views/shared/error_messages/_invalid_start_time.html.erb
+++ b/app/views/shared/error_messages/_invalid_start_time.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:start_time) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:start_time).first %>
+  </div>
+<% end %>

--- a/app/views/shared/error_messages/_invalid_temperature.html.erb
+++ b/app/views/shared/error_messages/_invalid_temperature.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:temperature) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:temperature).first %>
+  </div>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,7 +13,19 @@ ja:
         next_fertilizer_day: 次の肥料/栄養剤散布予定日
         next_replant_day: 次の植替え予定日
         image: 株画像
+      log:
+        start_time: 記録日時
+        is_watered: 水やり
+        is_fertilized: 肥料/栄養剤
+        is_replanted: 植替え
+        memo: メモ
+        image: 画像
+        temperature: 気温
+        humidity: 湿度
+        light_start_at: 植物育成ライト点灯時刻
+        light_end_at: 植物育成ライト消灯時刻
     models:
       user: ユーザー
       plant: 株
+      log: ログ
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,8 +24,9 @@ ja:
         humidity: 湿度
         light_start_at: 植物育成ライト点灯時刻
         light_end_at: 植物育成ライト消灯時刻
+        plant_id: 株
+        plant: 株名称
     models:
       user: ユーザー
       plant: 株
       log: ログ
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,6 @@ Rails.application.routes.draw do
   root 'home#index'
   get 'users/account', to: 'users#show'
   resources :plants, except: :index
+  resources :logs, except: :index
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20231211120842_create_logs.rb
+++ b/db/migrate/20231211120842_create_logs.rb
@@ -1,0 +1,19 @@
+class CreateLogs < ActiveRecord::Migration[6.1]
+  def change
+    create_table :logs do |t|
+      t.datetime :start_time, null: false
+      t.boolean :is_watered
+      t.boolean :is_fertilized
+      t.boolean :is_replanted
+      t.text :memo
+      t.float :temperature
+      t.float :humidity
+      t.datetime :light_start_at
+      t.datetime :light_end_at
+      t.integer :user_id, null: false
+      t.integer :plant_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_09_091221) do
+ActiveRecord::Schema.define(version: 2023_12_11_120842) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -38,6 +38,22 @@ ActiveRecord::Schema.define(version: 2023_12_09_091221) do
     t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "logs", force: :cascade do |t|
+    t.datetime "start_time", null: false
+    t.boolean "is_watered"
+    t.boolean "is_fertilized"
+    t.boolean "is_replanted"
+    t.text "memo"
+    t.float "temperature"
+    t.float "humidity"
+    t.datetime "light_start_at"
+    t.datetime "light_end_at"
+    t.integer "user_id", null: false
+    t.integer "plant_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "plants", force: :cascade do |t|


### PR DESCRIPTION
概要
- Logモデルを生成
- バリデーションを設定
- 他のモデル(`User`, `Plant` モデル)とのリレーションを設定
- Logモデル関連の必要なルーティングとコントローラを準備
- ログ新規作成機能を実装
- 各株個別ページからログ新規作成画面への動線を用意