### PR TITLE
[Votalog]ログの編集/削除機能を実装

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -35,6 +35,9 @@ class LogsController < ApplicationController
   end
 
   def destroy
+    @log = Log.find(params[:id])
+    @log.destroy
+    redirect_to plant_path(@log.plant), notice: "ログを削除しました"
   end
 
   def log_params

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -21,9 +21,17 @@ class LogsController < ApplicationController
   end
 
   def edit
+    @log = Log.find(params[:id])
   end
 
   def update
+    @log = Log.find(params[:id])
+    if @log.update(log_params)
+      redirect_to plant_path(@log.plant), notice: "ログを更新しました"
+    else
+      flash.now[:alert] = "ログの更新に失敗しました"
+      render "edit"
+    end
   end
 
   def destroy

--- a/app/views/logs/edit.html.erb
+++ b/app/views/logs/edit.html.erb
@@ -1,0 +1,16 @@
+<section class="u-content-space">
+  <div class="container">
+    <header class="w-md50 mx-auto text-center mb-6">
+      <h2>ログ編集</h2>
+    </header>
+    <%= form_with model: @log do |f| %>
+      <%= render "shared/log_form", f: f %>
+      <div class="text-center mb-3">
+        <%= f.submit "ログを更新", class: "btn btn-secondary btn-lg" %>
+      </div>
+      <div class="text-center mb-2">
+        <%= link_to "キャンセル", :back, class: "btn btn-outline-secondary btn-lg" %>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -4,74 +4,7 @@
       <h2>新規ログ追加</h2>
     </header>
     <%= form_with model: @log do |f| %>
-      <div class="form-group mb-4">
-        <%= f.label :start_time, class: "u-font-size-90 required-column" %>
-        <%= f.datetime_field :start_time, autofocus: true, class: "form-control" %>
-        <%= render "shared/error_messages/invalid_start_time", resource: f.object %>
-      </div>
-      <div class="form-group mb-4">
-        <%= f.label :plant_id, class: "u-font-size-90 required-column" %>
-        <%= f.collection_select :plant_id, current_user.plants, :id, :name, { include_blank: "選択してください" }, { class: "form-control" } %>
-        <%= render "shared/error_messages/invalid_plant_id", resource: f.object %>
-      </div>
-      <div class="row pl-3">
-        <p class="u-font-size-90 mb-2">お世話内容</p>
-      </div>
-      <div class="row mb-4">
-        <div class="col-md-4 text-center">
-          <div class="custom-control custom-checkbox">
-            <%= f.check_box :is_watered, class: "custom-control-input" %>
-            <%= f.label :is_watered, class: "custom-control-label" %>
-          </div>
-        </div>
-        <div class="col-md-4 text-center">
-          <div class="custom-control custom-checkbox">
-            <%= f.check_box :is_fertilized, class: "custom-control-input" %>
-            <%= f.label :is_fertilized, class: "custom-control-label" %>
-          </div>
-        </div>
-        <div class="col-md-4 text-center">
-          <div class="custom-control custom-checkbox">
-            <%= f.check_box :is_replanted, class: "custom-control-input" %>
-            <%= f.label :is_replanted, class: "custom-control-label" %>
-          </div>
-        </div>
-      </div>
-      <div class="form-group mb-4">
-        <%= f.label :memo, class: "u-font-size-90" %>
-        <%= f.text_area :memo, placeholder: "メモ", class: "form-control" %>
-        <%= render "shared/error_messages/invalid_memo", resource: f.object %>
-      </div>
-      <div class="form-group mb-4">
-        <%= f.label :temperature, class: "u-font-size-90" %>
-        <%= f.number_field :temperature, step: "0.1", placeholder: "12.3", class: "form-control" %>
-        <%= render "shared/error_messages/invalid_temperature", resource: f.object %>
-      </div>
-      <div class="form-group mb-4">
-        <%= f.label :humidity, class: "u-font-size-90" %>
-        <%= f.number_field :humidity, step: "0.1", placeholder: "65.4", class: "form-control" %>
-        <%= render "shared/error_messages/invalid_humidity", resource: f.object %>
-      </div>
-      <div class="row">
-        <div class="col-md-6">
-          <div class="form-group mb-4">
-            <%= f.label :light_start_at, class: "u-font-size-90" %>
-            <%= f.datetime_field :light_start_at, class: "form-control" %>
-          </div>
-        </div>
-        <div class="col-md-6">
-          <div class="form-group mb-4">
-            <%= f.label :light_end_at, class: "u-font-size-90" %>
-            <%= f.datetime_field :light_end_at, class: "form-control" %>
-            <%= render "shared/error_messages/invalid_light_end_at", resource: f.object %>
-          </div>
-        </div>
-      </div>
-      <div class="form-group mb-6">
-        <%= f.label :image, class: "u-font-size-90" %>
-        <%= f.file_field :image, class: "form-control" %>
-        <%= render "shared/error_messages/invalid_image", resource: f.object %>
-      </div>
+      <%= render "shared/log_form", f: f %>
       <div class="text-center mb-3">
         <%= f.submit "ログを追加", class: "btn btn-secondary btn-lg" %>
       </div>

--- a/app/views/shared/_log_form.html.erb
+++ b/app/views/shared/_log_form.html.erb
@@ -1,0 +1,68 @@
+<div class="form-group mb-4">
+  <%= f.label :start_time, class: "u-font-size-90 required-column" %>
+  <%= f.datetime_field :start_time, autofocus: true, class: "form-control" %>
+  <%= render "shared/error_messages/invalid_start_time", resource: f.object %>
+</div>
+<div class="form-group mb-4">
+  <%= f.label :plant_id, class: "u-font-size-90 required-column" %>
+  <%= f.collection_select :plant_id, current_user.plants, :id, :name, { include_blank: "選択してください" }, { class: "form-control" } %>
+  <%= render "shared/error_messages/invalid_plant_id", resource: f.object %>
+</div>
+<div class="row pl-3">
+  <p class="u-font-size-90 mb-2">お世話内容</p>
+</div>
+<div class="row mb-4">
+  <div class="col-md-4 text-center">
+    <div class="custom-control custom-checkbox">
+      <%= f.check_box :is_watered, class: "custom-control-input" %>
+      <%= f.label :is_watered, class: "custom-control-label" %>
+    </div>
+  </div>
+  <div class="col-md-4 text-center">
+    <div class="custom-control custom-checkbox">
+      <%= f.check_box :is_fertilized, class: "custom-control-input" %>
+      <%= f.label :is_fertilized, class: "custom-control-label" %>
+    </div>
+  </div>
+  <div class="col-md-4 text-center">
+    <div class="custom-control custom-checkbox">
+      <%= f.check_box :is_replanted, class: "custom-control-input" %>
+      <%= f.label :is_replanted, class: "custom-control-label" %>
+    </div>
+  </div>
+</div>
+<div class="form-group mb-4">
+  <%= f.label :memo, class: "u-font-size-90" %>
+  <%= f.text_area :memo, placeholder: "メモ", class: "form-control" %>
+  <%= render "shared/error_messages/invalid_memo", resource: f.object %>
+</div>
+<div class="form-group mb-4">
+  <%= f.label :temperature, class: "u-font-size-90" %>
+  <%= f.number_field :temperature, step: "0.1", placeholder: "12.3", class: "form-control" %>
+  <%= render "shared/error_messages/invalid_temperature", resource: f.object %>
+</div>
+<div class="form-group mb-4">
+  <%= f.label :humidity, class: "u-font-size-90" %>
+  <%= f.number_field :humidity, step: "0.1", placeholder: "65.4", class: "form-control" %>
+  <%= render "shared/error_messages/invalid_humidity", resource: f.object %>
+</div>
+<div class="row">
+  <div class="col-md-6">
+    <div class="form-group mb-4">
+      <%= f.label :light_start_at, class: "u-font-size-90" %>
+      <%= f.datetime_field :light_start_at, class: "form-control" %>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="form-group mb-4">
+      <%= f.label :light_end_at, class: "u-font-size-90" %>
+      <%= f.datetime_field :light_end_at, class: "form-control" %>
+      <%= render "shared/error_messages/invalid_light_end_at", resource: f.object %>
+    </div>
+  </div>
+</div>
+<div class="form-group mb-6">
+  <%= f.label :image, class: "u-font-size-90" %>
+  <%= f.file_field :image, class: "form-control" %>
+  <%= render "shared/error_messages/invalid_image", resource: f.object %>
+</div>


### PR DESCRIPTION
- ログ確認画面からログ編集画面へ遷移し、ログを編集できる機能を追加
  - 編集成功後は株の個別ページにリダイレクトする仕様とした
  - 編集失敗時は編集画面をレンダリングして再描画
- ログ確認画面からログ削除ボタンを押下すると該当するログを削除できる機能を追加
  - 削除後は株の個別ページにリダイレクトする仕様