### PR TITLE
[Votalog] 直近のお世話予定をログイン時のトップページに一覧表示する機能を実装

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,11 @@
 class HomeController < ApplicationController
   def index
     @user = current_user
+    @todays_water_scheduled_plants = Plant.search_todays_schedules(@user, "water")
+    @todays_fertilizer_scheduled_plants = Plant.search_todays_schedules(@user, "fertilizer")
+    @todays_replant_scheduled_plants = Plant.search_todays_schedules(@user, "replant")
+    @tomorrows_water_scheduled_plants = Plant.search_tomorrows_schedules(@user, "water")
+    @tomorrows_fertilizer_scheduled_plants = Plant.search_tomorrows_schedules(@user, "fertilizer")
+    @tomorrows_replant_scheduled_plants = Plant.search_tomorrows_schedules(@user, "replant")
   end
 end

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -36,4 +36,12 @@ class Plant < ApplicationRecord
       errors.add(:next_replant_day, "は今日以降の日付を選択してください")
     end
   end
+
+  def self.search_todays_schedules(user, params)
+    Plant.where("user_id = ? and next_#{params}_day = ?", user.id, Time.zone.today)
+  end
+
+  def self.search_tomorrows_schedules(user, params)
+    Plant.where("user_id = ? and next_#{params}_day = ?", user.id, Time.zone.tomorrow)
+  end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,118 @@
 <% if user_signed_in? %>
-  <%= render  "shared/my_shelf", resources: @user.plants %>
+  <section class="u-content-space">
+    <div class="container">
+      <header class="w-md50 mx-automb-6 mb-4 d-flex justify-content-between align-items-center">
+        <h2 class="mb-0">お世話スケジュール</h2>
+      </header>
+      <div class="row mb-6">
+        <div class="col-md-4 text-center bg-light p-3">
+          <p>今日水やり予定の株</p>
+          <hr class="mb-4">
+          <div>
+            <% if @todays_water_scheduled_plants.present? %>
+              <% @todays_water_scheduled_plants.each do |plant| %>
+                <p class="mb-2">
+                  <%= link_to plant_path(plant) do %>
+                    <%= plant.name %>
+                  <% end %>
+                </p>
+              <% end %>
+            <% else %>
+              <p class="mb-2">なし</p>
+            <% end %>
+          </div>
+        </div>
+        <div class="col-md-4 text-center bg-light p-3">
+          <p>今日肥料/栄養剤散布予定の株</p>
+          <hr class="mb-4">
+          <div>
+            <% if @todays_fertilizer_scheduled_plants.present? %>
+              <% @todays_fertilizer_scheduled_plants.each do |plant| %>
+                <p class="mb-2">
+                  <%= link_to plant_path(plant) do %>
+                    <%= plant.name %>
+                  <% end %>
+                </p>
+              <% end %>
+            <% else %>
+              <p class="mb-2">なし</p>
+            <% end %>
+          </div>
+        </div>
+        <div class="col-md-4 text-center bg-light p-3">
+          <p>今日植替え予定の株</p>
+          <hr class="mb-4">
+          <div>
+            <% if @todays_replant_scheduled_plants.present? %>
+              <% @todays_replant_scheduled_plants.each do |plant| %>
+                <p class="mb-2">
+                  <%= link_to plant_path(plant) do %>
+                    <%= plant.name %>
+                  <% end %>
+                </p>
+              <% end %>
+            <% else %>
+              <p class="mb-2">なし</p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-4 text-center bg-light p-3">
+          <p>明日水やり予定の株</p>
+          <hr class="mb-4">
+          <div>
+            <% if @tomorrows_water_scheduled_plants.present? %>
+              <% @tomorrows_water_scheduled_plants.each do |plant| %>
+                <p class="mb-2">
+                  <%= link_to plant_path(plant) do %>
+                    <%= plant.name %>
+                  <% end %>
+                </p>
+              <% end %>
+            <% else %>
+              <p class="mb-2">なし</p>
+            <% end %>
+          </div>
+        </div>
+        <div class="col-md-4 text-center bg-light p-3">
+          <p>明日肥料/栄養剤散布予定の株</p>
+          <hr class="mb-4">
+          <div>
+            <% if @tomorrows_fertilizer_scheduled_plants.present? %>
+              <% @tomorrows_fertilizer_scheduled_plants.each do |plant| %>
+                <p class="mb-2">
+                  <%= link_to plant_path(plant) do %>
+                    <%= plant.name %>
+                  <% end %>
+                </p>
+              <% end %>
+            <% else %>
+              <p class="mb-2">なし</p>
+            <% end %>
+          </div>
+        </div>
+        <div class="col-md-4 text-center bg-light p-3">
+          <p>明日植替え予定の株</p>
+          <hr class="mb-4">
+          <div>
+            <% if @tomorrows_replant_scheduled_plants.present? %>
+              <% @tomorrows_replant_scheduled_plants.each do |plant| %>
+                <p class="mb-2">
+                  <%= link_to plant_path(plant) do %>
+                    <%= plant.name %>
+                  <% end %>
+                </p>
+              <% end %>
+            <% else %>
+              <p class="mb-2">なし</p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <%= render "shared/my_shelf", resources: @user.plants %>
 <% else %>
   <%= render "shared/firstview" %>
   <%= render "shared/about" %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -8,106 +8,34 @@
         <div class="col-md-4 text-center bg-light p-3">
           <p>今日水やり予定の株</p>
           <hr class="mb-4">
-          <div>
-            <% if @todays_water_scheduled_plants.present? %>
-              <% @todays_water_scheduled_plants.each do |plant| %>
-                <p class="mb-2">
-                  <%= link_to plant_path(plant) do %>
-                    <%= plant.name %>
-                  <% end %>
-                </p>
-              <% end %>
-            <% else %>
-              <p class="mb-2">なし</p>
-            <% end %>
-          </div>
+          <%= render "shared/schedule_list", schedules: @todays_water_scheduled_plants %>
         </div>
         <div class="col-md-4 text-center bg-light p-3">
           <p>今日肥料/栄養剤散布予定の株</p>
           <hr class="mb-4">
-          <div>
-            <% if @todays_fertilizer_scheduled_plants.present? %>
-              <% @todays_fertilizer_scheduled_plants.each do |plant| %>
-                <p class="mb-2">
-                  <%= link_to plant_path(plant) do %>
-                    <%= plant.name %>
-                  <% end %>
-                </p>
-              <% end %>
-            <% else %>
-              <p class="mb-2">なし</p>
-            <% end %>
-          </div>
+          <%= render "shared/schedule_list", schedules: @todays_fertilizer_scheduled_plants %>
         </div>
         <div class="col-md-4 text-center bg-light p-3">
           <p>今日植替え予定の株</p>
           <hr class="mb-4">
-          <div>
-            <% if @todays_replant_scheduled_plants.present? %>
-              <% @todays_replant_scheduled_plants.each do |plant| %>
-                <p class="mb-2">
-                  <%= link_to plant_path(plant) do %>
-                    <%= plant.name %>
-                  <% end %>
-                </p>
-              <% end %>
-            <% else %>
-              <p class="mb-2">なし</p>
-            <% end %>
-          </div>
+          <%= render "shared/schedule_list", schedules: @todays_replant_scheduled_plants %>
         </div>
       </div>
       <div class="row">
         <div class="col-md-4 text-center bg-light p-3">
           <p>明日水やり予定の株</p>
           <hr class="mb-4">
-          <div>
-            <% if @tomorrows_water_scheduled_plants.present? %>
-              <% @tomorrows_water_scheduled_plants.each do |plant| %>
-                <p class="mb-2">
-                  <%= link_to plant_path(plant) do %>
-                    <%= plant.name %>
-                  <% end %>
-                </p>
-              <% end %>
-            <% else %>
-              <p class="mb-2">なし</p>
-            <% end %>
-          </div>
+          <%= render "shared/schedule_list", schedules: @tomorrows_water_scheduled_plants %>
         </div>
         <div class="col-md-4 text-center bg-light p-3">
           <p>明日肥料/栄養剤散布予定の株</p>
           <hr class="mb-4">
-          <div>
-            <% if @tomorrows_fertilizer_scheduled_plants.present? %>
-              <% @tomorrows_fertilizer_scheduled_plants.each do |plant| %>
-                <p class="mb-2">
-                  <%= link_to plant_path(plant) do %>
-                    <%= plant.name %>
-                  <% end %>
-                </p>
-              <% end %>
-            <% else %>
-              <p class="mb-2">なし</p>
-            <% end %>
-          </div>
+          <%= render "shared/schedule_list", schedules: @tomorrows_fertilizer_scheduled_plants %>
         </div>
         <div class="col-md-4 text-center bg-light p-3">
           <p>明日植替え予定の株</p>
           <hr class="mb-4">
-          <div>
-            <% if @tomorrows_replant_scheduled_plants.present? %>
-              <% @tomorrows_replant_scheduled_plants.each do |plant| %>
-                <p class="mb-2">
-                  <%= link_to plant_path(plant) do %>
-                    <%= plant.name %>
-                  <% end %>
-                </p>
-              <% end %>
-            <% else %>
-              <p class="mb-2">なし</p>
-            <% end %>
-          </div>
+          <%= render "shared/schedule_list", schedules: @tomorrows_replant_scheduled_plants %>
         </div>
       </div>
     </div>

--- a/app/views/shared/_schedule_list.html.erb
+++ b/app/views/shared/_schedule_list.html.erb
@@ -1,0 +1,13 @@
+<div>
+  <% if schedules.present? %>
+    <% schedules.each do |plant| %>
+      <p class="mb-2">
+        <%= link_to plant_path(plant) do %>
+          <%= plant.name %>
+        <% end %>
+      </p>
+    <% end %>
+  <% else %>
+    <p class="mb-2">なし</p>
+  <% end %>
+</div>


### PR DESCRIPTION
概要
- 当日または翌日に水やり・肥料/栄養剤散布・植替えのいずれかの予定を入れている株名称を、ログイン時のトップページにお世話予定内容ごとに一覧表示
  - 株名称を押下すると各株個別ページに遷移