### PR TITLE
[Votalog] 株個別ページのajaxフォームからお世話予定の追加/変更に成功後、画面が反応しなくなるバグの修正

### DIFF
--- a/app/views/plants/update.js.erb
+++ b/app/views/plants/update.js.erb
@@ -1,3 +1,4 @@
+$('.modal-backdrop').remove();
 $('#nextDayModal').modal('hide');
 $('.js-next-water-day').empty();
 $('.js-next-water-day').append("<%= escape_javascript(render partial: "plants/next_water_day", locals: { plant: @plant }) %>");


### PR DESCRIPTION
概要
- 次回水やり予定日等のお世話予定の追加/変更成功時、モーダルの背景部分の要素の削除ができていなかったため、背景部分を削除してその下のレイヤーのボタン等を正常に押下できるよう修正