### PR TITLE
[Votalog] ログインユーザー自身の株/お世話ログ以外の参照・編集・削除が行えないように設定を追加

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,5 +1,6 @@
 class LogsController < ApplicationController
   before_action :authenticate_user!
+  before_action :ensure_correct_user, only: [:edit, :update, :show, :destroy]
 
   def new
     @log = Log.new
@@ -42,5 +43,12 @@ class LogsController < ApplicationController
 
   def log_params
     params.require(:log).permit(:start_time, :is_watered, :is_fertilized, :is_replanted, :memo, :image, :temperature, :humidity, :light_start_at, :light_end_at, :plant_id)
+  end
+
+  def ensure_correct_user
+    log = Log.find(params[:id])
+    unless log.user == current_user
+      redirect_to root_path, alert: "自分のお世話ログ以外の参照・編集・削除等の操作は行えません"
+    end
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -41,14 +41,16 @@ class LogsController < ApplicationController
     redirect_to plant_path(@log.plant), notice: "ログを削除しました"
   end
 
-  def log_params
-    params.require(:log).permit(:start_time, :is_watered, :is_fertilized, :is_replanted, :memo, :image, :temperature, :humidity, :light_start_at, :light_end_at, :plant_id)
-  end
+  private
 
-  def ensure_correct_user
-    log = Log.find(params[:id])
-    unless log.user == current_user
-      redirect_to root_path, alert: "自分のお世話ログ以外の参照・編集・削除等の操作は行えません"
+    def log_params
+      params.require(:log).permit(:start_time, :is_watered, :is_fertilized, :is_replanted, :memo, :image, :temperature, :humidity, :light_start_at, :light_end_at, :plant_id)
     end
-  end
+
+    def ensure_correct_user
+      log = Log.find(params[:id])
+      unless log.user == current_user
+        redirect_to root_path, alert: "自分のお世話ログ以外の参照・編集・削除等の操作は行えません"
+      end
+    end
 end

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -1,5 +1,6 @@
 class PlantsController < ApplicationController
   before_action :authenticate_user!
+  before_action :ensure_correct_user, only: [:edit, :update, :show, :destroy]
 
   def new
     @plant = Plant.new
@@ -46,5 +47,12 @@ class PlantsController < ApplicationController
 
   def plant_params
     params.require(:plant).permit(:name, :next_water_day, :next_fertilizer_day, :next_replant_day, :image)
+  end
+
+  def ensure_correct_user
+    plant = Plant.find(params[:id])
+    unless plant.user == current_user
+      redirect_to root_path, alert: "自分が所持している株以外の参照・編集・削除等の操作は行えません"
+    end
   end
 end

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -45,14 +45,16 @@ class PlantsController < ApplicationController
     redirect_to root_path, notice: "#{@plant.name}を削除しました"
   end
 
-  def plant_params
-    params.require(:plant).permit(:name, :next_water_day, :next_fertilizer_day, :next_replant_day, :image)
-  end
+  private
 
-  def ensure_correct_user
-    plant = Plant.find(params[:id])
-    unless plant.user == current_user
-      redirect_to root_path, alert: "自分が所持している株以外の参照・編集・削除等の操作は行えません"
+    def plant_params
+      params.require(:plant).permit(:name, :next_water_day, :next_fertilizer_day, :next_replant_day, :image)
     end
-  end
+
+    def ensure_correct_user
+      plant = Plant.find(params[:id])
+      unless plant.user == current_user
+        redirect_to root_path, alert: "自分が所持している株以外の参照・編集・削除等の操作は行えません"
+      end
+    end
 end


### PR DESCRIPTION
概要
- URLから直接他のユーザーの株情報やお世話ログの参照・編集・削除を行おうとした場合、フラッシュメッセージを表示してトップページにリダイレクトするよう設定を追加
