### PR TITLE
[Votalog] 株名称または画像のupdate時に、次回お世話予定日のバリデーションに抵触してupdateできないことがある不具合の修正

### DIFF
--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -1,9 +1,6 @@
 class Plant < ApplicationRecord
   validates :name, presence: true
   validate :is_file_type_valid?
-  validate :is_next_water_day_after_today?
-  validate :is_next_fertilizer_day_after_today?
-  validate :is_next_replant_day_after_today?
 
   belongs_to :user
   has_many :logs, dependent: :destroy
@@ -16,24 +13,6 @@ class Plant < ApplicationRecord
     valid_file_types = ["image/png", "image/jpg", "image/gif"]
     unless valid_file_types.include?(image.blob.content_type)
       errors.add(:image, "には拡張子が.png, .jpg, .gifのいずれかのファイルを添付してください")
-    end
-  end
-
-  def is_next_water_day_after_today?
-    if next_water_day.present? && next_water_day < Time.zone.today
-      errors.add(:next_water_day, "は今日以降の日付を選択してください")
-    end
-  end
-
-  def is_next_fertilizer_day_after_today?
-    if next_fertilizer_day.present? && next_fertilizer_day < Time.zone.today
-      errors.add(:next_fertilizer_day, "は今日以降の日付を選択してください")
-    end
-  end
-
-  def is_next_replant_day_after_today?
-    if next_replant_day.present? && next_replant_day < Time.zone.today
-      errors.add(:next_replant_day, "は今日以降の日付を選択してください")
     end
   end
 

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -95,15 +95,15 @@
         <div class="modal-body">
           <div class="form-group mb-4">
             <%= f.label :next_water_day, class: "u-font-size-90" %>
-            <%= f.date_field :next_water_day, autofocus: true, class: "form-control" %>
+            <%= f.date_field :next_water_day, autofocus: true, min: Time.zone.today, class: "form-control" %>
           </div>
           <div class="form-group mb-4">
             <%= f.label :next_fertilizer_day, class: "u-font-size-90" %>
-            <%= f.date_field :next_fertilizer_day, class: "form-control" %>
+            <%= f.date_field :next_fertilizer_day, min: Time.zone.today, class: "form-control" %>
           </div>
           <div class="form-group mb-4">
             <%= f.label :next_replant_day, class: "u-font-size-90" %>
-            <%= f.date_field :next_replant_day, class: "form-control" %>
+            <%= f.date_field :next_replant_day, min: Time.zone.today, class: "form-control" %>
           </div>
           <div class="js-error-message"></div>
         </div>


### PR DESCRIPTION
概要
- モデル側でお世話予定日(`next_water_day`カラム、`next_fertilizer_day`カラム、`next_replant_day`カラム)に対して当日以降の日付入力を求めるバリデーションを設定していたが、元々設定していたいずれかのお世話予定日を過ぎた状態で株名称または株画像を編集しようとすると、お世話予定日のバリデーションに抵触してしまいupdate処理に失敗していた
  - 次回お世話予定日を入力する際の`date_field`に最小値を設定することで当日以降の日付を入力してもらえるよう誘導し、モデルでのカスタムバリデーションはなくして株名称や画像はお世話予定日関連のカラム状況に依存せず更新することができるようにしました