### PR TITLE
[Votalog]タブのタイトルがページの内容ごとに動的に表示されるよう変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  DEFAULT_TITLE = "Votalog".freeze
+
+  def display_page_title(page_title)
+    if page_title.blank?
+      DEFAULT_TITLE
+    else
+      page_title + " | " + DEFAULT_TITLE
+    end
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :html_title, "アカウント情報編集" %>
+
 <section class="u-content-space">
   <div class="container">
     <header class="w-md50 mx-auto text-center mb-6">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :html_title, "新規登録" %>
+
 <section class="u-content-space">
   <div class="container">
     <header class="w-md50 mx-auto text-center mb-6">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :html_title, "ログイン" %>
+
 <section class="u-content-space">
   <div class="container">
     <header class="w-md50 mx-auto text-center mb-6">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
   <head>
-    <title>Votalog</title>
+    <title><%= display_page_title(yield(:html_title)) %></title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width,initial-scale=1, shrink-to-fit=no">
     <%= csrf_meta_tags %>

--- a/app/views/logs/edit.html.erb
+++ b/app/views/logs/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :html_title, "ログ編集" %>
+
 <section class="u-content-space">
   <div class="container">
     <header class="w-md50 mx-auto text-center mb-6">

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :html_title, "新規ログ追加" %>
+
 <section class="u-content-space">
   <div class="container">
     <header class="w-md50 mx-auto text-center mb-6">

--- a/app/views/logs/show.html.erb
+++ b/app/views/logs/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :html_title, "ログ詳細" %>
+
 <section class="u-content-space">
   <div class="container">
     <header class="w-md50 mx-auto text-center mb-6">

--- a/app/views/plants/edit.html.erb
+++ b/app/views/plants/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :html_title, "株情報編集" %>
+
 <section class="u-content-space">
   <div class="container">
     <header  class="w-md50 mx-auto text-center mb-6">

--- a/app/views/plants/new.html.erb
+++ b/app/views/plants/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :html_title, "新規株登録" %>
+
 <section class="u-content-space">
   <div class="container">
     <header  class="w-md50 mx-auto text-center mb-6">

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :html_title, @plant.name %>
+
 <section class="u-content-space">
   <div class="container">
     <header class="w-md50 mx-automb-6 mb-4 d-flex justify-content-between align-items-center">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :html_title, "アカウント情報" %>
+
 <section class="u-content-space">
   <div class="container">
     <header class="w-md50 mx-auto text-center mb-6">


### PR DESCRIPTION
概要
- `head`の`title`タグがコンテンツに応じて変わるようにするモジュールを追加
- 各ビューファイルのタイトルを必要に応じて指定