### PR TITLE
[Votalog] ユーザー設定機能を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'devise'
 gem 'rails-i18n'
 gem 'simple_calendar'
 gem 'dotenv-rails'
+gem 'httpclient'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'devise'
 gem 'rails-i18n'
 gem 'simple_calendar'
+gem 'dotenv-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     ffi (1.16.3)
     globalid (1.2.1)
@@ -255,6 +259,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   devise
+  dotenv-rails
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (~> 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -260,6 +261,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   devise
   dotenv-rails
+  httpclient
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (~> 3.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,6 @@ class ApplicationController < ActionController::Base
 
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-      devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name, :zipcode, :latitude, :longitude])
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,7 @@ class UsersController < ApplicationController
   end
 
   def edit
+    @user = User.find(current_user.id)
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
+  before_action :ensure_correct_user, only: :update
 
   def show
     @user = User.find(current_user.id)
@@ -41,7 +42,16 @@ class UsersController < ApplicationController
     end
   end
 
-  def user_params
-    params.require(:user).permit(:zipcode, :latitude, :longitude)
-  end
+  private
+
+    def user_params
+      params.require(:user).permit(:zipcode, :latitude, :longitude)
+    end
+
+    def ensure_correct_user
+      user = User.find(params[:id])
+      unless user == current_user
+        redirect_to users_settings_path, alert: "自分のユーザー設定以外の変更は行えません"
+      end
+    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@ class UsersController < ApplicationController
   end
 
   def settings
+    @user = User.find(current_user.id)
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,5 +14,34 @@ class UsersController < ApplicationController
   end
 
   def update
+    @user = User.find(params[:id])
+    if params[:user][:zipcode].present?
+      @user.latitude, @user.longitude = User.get_users_location(params[:user][:zipcode])
+      if @user.latitude && @user.longitude
+        if @user.update(user_params)
+          redirect_to users_settings_path, notice: "ユーザー設定を更新しました"
+        else
+          flash.now[:alert] = "ユーザー設定の更新に失敗しました"
+          render "edit"
+        end
+      else
+        redirect_to users_settings_edit_path, alert: "位置情報の取得に失敗しました。郵便番号が誤っていないか確認してください"
+      end
+    elsif @user.zipcode
+      @user.latitude = nil
+      @user.longitude = nil
+      if @user.update(user_params)
+        redirect_to users_settings_path, notice: "ユーザー設定を更新しました"
+      else
+        flash.now[:alert] = "ユーザー設定の更新に失敗しました"
+        render "edit"
+      end
+    else
+      redirect_to users_settings_path
+    end
+  end
+
+  def user_params
+    params.require(:user).permit(:zipcode, :latitude, :longitude)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,10 @@ class UsersController < ApplicationController
 
   def settings
     @user = User.find(current_user.id)
+    if @user.zipcode
+      format_zipcode = format("%07d", @user.zipcode).to_s
+      @zipcode = format_zipcode.slice(0..2) + " - " + format_zipcode.slice(3..6)
+    end
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,4 +4,13 @@ class UsersController < ApplicationController
   def show
     @user = User.find(current_user.id)
   end
+
+  def settings
+  end
+
+  def edit
+  end
+
+  def update
+  end
 end

--- a/app/javascript/packs/settings_edit.js
+++ b/app/javascript/packs/settings_edit.js
@@ -1,0 +1,1 @@
+import "src/js/settings_edit.js";

--- a/app/javascript/src/js/settings_edit.js
+++ b/app/javascript/src/js/settings_edit.js
@@ -1,0 +1,1 @@
+history.pushState(null, null, "/users/settings/edit");

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :name, presence: true
+  validates :zipcode, length: { is: 7 }, allow_nil: true
 
   has_many :plants, dependent: :destroy
   has_many :logs, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :name, presence: true
-  validates :zipcode, length: { is: 7 }, allow_nil: true
+  validates :zipcode, length: { in: 5..7 }, numericality: { only_integer: true }, allow_nil: true
 
   has_many :plants, dependent: :destroy
   has_many :logs, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  require 'httpclient'
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -14,5 +15,21 @@ class User < ApplicationRecord
       user.password = SecureRandom.urlsafe_base64
       user.name = "ゲストユーザー"
     end
+  end
+
+  def self.get_users_location(zipcode)
+    client = HTTPClient.new
+    url = "https://geoapi.heartrails.com/api/json?method=searchByPostal&postal=" + zipcode
+    response = client.get(url)
+    res = JSON.parse(response.body)
+    begin
+      latitude = res["response"]["location"][0]["y"]
+      longitude = res["response"]["location"][0]["x"]
+    rescue => e
+      logger.error("位置情報の取得に失敗しました。エラー: #{e}")
+      latitude = nil
+      longitude = nil
+    end
+    return latitude, longitude
   end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -22,6 +22,7 @@
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <%= link_to "アカウント", users_account_path, class: "dropdown-item" %>
+                <%= link_to "設定", users_settings_path, class: "dropdown-item" %>
                 <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
               </div>
             </div>

--- a/app/views/shared/error_messages/_invalid_zipcode.html.erb
+++ b/app/views/shared/error_messages/_invalid_zipcode.html.erb
@@ -1,0 +1,5 @@
+<% if resource.errors.include?(:zipcode) %>
+  <div class="invalid-input">
+    <%= resource.errors.full_messages_for(:zipcode).first %>
+  </div>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,29 @@
+<% content_for :html_title, "ユーザー設定編集" %>
+
+<section class="u-content-space">
+  <div class="container">
+    <header class="w-md50 mx-auto text-center mb-6">
+      <h2>ユーザー設定編集</h2>
+    </header>
+    <%= form_with model: @user do |f| %>
+      <div class="form-group mb-6">
+        <%= f.label :zipcode, class: "u-font-size-90" %>
+        <%= f.number_field :zipcode, autofocus: true, placeholder: "0010010", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_zipcode", resource: f.object %>
+      </div>
+      <div class="form-group mb-6">
+        <%= f.label :current_password, class: "u-font-size-90" %> <span class="u-font-size-90">(変更には現在のパスワードが必要です)</span>
+        <%= f.password_field :current_password, class: "form-control" %>
+        <%= render "shared/error_messages/invalid_current_password", resource: f.object %>
+      </div>
+      <div class="text-center mb-6">
+        <%= f.submit "変更を保存", class: "btn btn-secondary btn-lg" %>
+        <%= link_to "キャンセル", users_settings_path, class: "btn btn-outline-secondary btn-lg" %>
+      </div>
+    <% end %>
+  </div>
+</section>
+
+<% if @user.errors.any? %>
+  <%= javascript_pack_tag "edit" %>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -11,11 +11,6 @@
         <%= f.number_field :zipcode, autofocus: true, placeholder: "0010010", class: "form-control" %>
         <%= render "shared/error_messages/invalid_zipcode", resource: f.object %>
       </div>
-      <div class="form-group mb-6">
-        <%= f.label :current_password, class: "u-font-size-90" %> <span class="u-font-size-90">(変更には現在のパスワードが必要です)</span>
-        <%= f.password_field :current_password, class: "form-control" %>
-        <%= render "shared/error_messages/invalid_current_password", resource: f.object %>
-      </div>
       <div class="text-center mb-6">
         <%= f.submit "変更を保存", class: "btn btn-secondary btn-lg" %>
         <%= link_to "キャンセル", users_settings_path, class: "btn btn-outline-secondary btn-lg" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -25,5 +25,5 @@
 </section>
 
 <% if @user.errors.any? %>
-  <%= javascript_pack_tag "edit" %>
+  <%= javascript_pack_tag "settings_edit" %>
 <% end %>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -1,0 +1,24 @@
+<% content_for :html_title, "ユーザー設定" %>
+
+<section class="u-content-space">
+  <div class="container">
+    <header class="w-md50 mx-auto text-center mb-6">
+      <h2>ユーザー設定</h2>
+    </header>
+    <div class="row mb-2">
+      <div class="col-md-6">
+        <p class="text-center mb-0">郵便番号</p>
+      </div>
+      <div class="col-md-6">
+        <p class="text-center mb-0">
+          <%= @user.zipcode %>
+        </p>
+      </div>
+    </div>
+    <hr class="mb-4">
+    <p class="text-center mb-6">※郵便番号を登録すると、お世話ログの作成時に自動で現在地の気温と湿度が入力されます(手動で入力することもできます)</p>
+    <div class="text-center mb-2">
+      <%= link_to "設定の変更", users_settings_edit_path, class: "btn btn-outline-secondary" %>
+    </div>
+  </div>
+</section>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -11,7 +11,9 @@
       </div>
       <div class="col-md-6">
         <p class="text-center mb-0">
-          <%= @user.zipcode %>
+          <% if @user.zipcode %>
+            〒 <%= @zipcode %>
+          <% end %>
         </p>
       </div>
     </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
         password: パスワード
         password_confirmation: パスワード（確認用）
         current_password: 現在のパスワード
+        zipcode: 郵便番号
       plant:
         name: 株名称
         next_water_day: 次の水やり予定日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
   end
   root 'home#index'
   get 'users/account', to: 'users#show'
+  get 'users/settings', to: 'users#settings'
+  get 'users/settings/edit', to: 'users#edit'
+  resources :users, only: :update
   resources :plants, except: :index
   resources :logs, except: :index
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20231218171726_add_column_to_users.rb
+++ b/db/migrate/20231218171726_add_column_to_users.rb
@@ -1,0 +1,6 @@
+class AddColumnToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :latitude, :float
+    add_column :users, :longitude, :float
+  end
+end

--- a/db/migrate/20231218181441_add_zipcode_column_to_users.rb
+++ b/db/migrate/20231218181441_add_zipcode_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddZipcodeColumnToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :zipcode, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_18_171726) do
+ActiveRecord::Schema.define(version: 2023_12_18_181441) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 2023_12_18_171726) do
     t.datetime "updated_at", precision: 6, null: false
     t.float "latitude"
     t.float "longitude"
+    t.integer "zipcode"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_11_120842) do
+ActiveRecord::Schema.define(version: 2023_12_18_171726) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -75,6 +75,8 @@ ActiveRecord::Schema.define(version: 2023_12_11_120842) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.float "latitude"
+    t.float "longitude"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
概要
- `users`テーブルに下記カラムを追加
  - `latitude`(float)
  - `longitude`(float)
  - `zipcode`(integer)
- ユーザー設定確認画面、ユーザー設定編集画面を実装
  - ルーティング、コントローラ設定済み
  - ログイン時ヘッダのプルダウンメニューから設定確認画面への動線を用意
- ユーザーが設定編集画面から郵便番号を登録すると[外部API](https://geoapi.heartrails.com/api.html#postal)を叩いて緯度と経度の情報を取得し`users`テーブルに保存する機能を実装
  - ユーザーが郵便番号を削除した場合は位置情報も合わせてDBから削除する仕様とした
- updateアクションのみ`id`をURLに含んでいるため、他のユーザーの設定を更新できないよう`before_action`で制御