### PR TITLE
[Votalog] お世話ログの新規作成時、ユーザーが位置情報を登録している場合は登録地点の気温と湿度が入力補完される機能を実装

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -4,6 +4,16 @@ class LogsController < ApplicationController
 
   def new
     @log = Log.new
+    @user = current_user
+    if @user.latitude && @user.longitude
+      @temperature, @humidity = Log.get_weather_info(@user.latitude, @user.longitude)
+      if @temperature.nil? || @humidity.nil?
+        flash.now[:alert] = "気象情報の取得に失敗しました"
+      end
+    else
+      @temperature = nil
+      @humidity = nil
+    end
   end
 
   def create

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -38,7 +38,7 @@ class LogsController < ApplicationController
   def update
     @log = Log.find(params[:id])
     if @log.update(log_params)
-      redirect_to plant_path(@log.plant), notice: "ログを更新しました"
+      redirect_to log_path(@log), notice: "ログを更新しました"
     else
       flash.now[:alert] = "ログの更新に失敗しました"
       render "edit"

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -29,7 +29,7 @@ class Log < ApplicationRecord
 
   def self.get_weather_info(latitude, longitude)
     client = HTTPClient.new
-    url = "https://api.openweathermap.org/data/2.5/weather?lat=" + latitude.to_s + "&lon=" + longitude.to_s + "&units=metric&appid="+ ENV['OPEN_WEATHER_API_KEY']
+    url = "https://api.openweathermap.org/data/2.5/weather?lat=" + latitude.to_s + "&lon=" + longitude.to_s + "&units=metric&appid=" + ENV['OPEN_WEATHER_API_KEY']
     response = client.get(url)
     res = JSON.parse(response.body)
     begin

--- a/app/views/logs/edit.html.erb
+++ b/app/views/logs/edit.html.erb
@@ -7,6 +7,16 @@
     </header>
     <%= form_with model: @log do |f| %>
       <%= render "shared/log_form", f: f %>
+      <div class="form-group mb-4">
+        <%= f.label :temperature, class: "u-font-size-90" %>
+        <%= f.number_field :temperature, step: "0.1", placeholder: "12.3", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_temperature", resource: f.object %>
+      </div>
+      <div class="form-group mb-4">
+        <%= f.label :humidity, class: "u-font-size-90" %>
+        <%= f.number_field :humidity, step: "0.1", placeholder: "65.4", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_humidity", resource: f.object %>
+      </div>
       <div class="text-center mb-3">
         <%= f.submit "ログを更新", class: "btn btn-secondary btn-lg" %>
       </div>

--- a/app/views/logs/edit.html.erb
+++ b/app/views/logs/edit.html.erb
@@ -12,7 +12,7 @@
         <%= f.number_field :temperature, step: "0.1", placeholder: "12.3", class: "form-control" %>
         <%= render "shared/error_messages/invalid_temperature", resource: f.object %>
       </div>
-      <div class="form-group mb-4">
+      <div class="form-group mb-6">
         <%= f.label :humidity, class: "u-font-size-90" %>
         <%= f.number_field :humidity, step: "0.1", placeholder: "65.4", class: "form-control" %>
         <%= render "shared/error_messages/invalid_humidity", resource: f.object %>

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -9,12 +9,12 @@
       <%= render "shared/log_form", f: f %>
       <div class="form-group mb-4">
         <%= f.label :temperature, class: "u-font-size-90" %>
-        <%= f.number_field :temperature, step: "0.1", placeholder: "12.3", class: "form-control" %>
+        <%= f.number_field :temperature, step: "0.1", placeholder: "12.3", value: @temperature, class: "form-control" %>
         <%= render "shared/error_messages/invalid_temperature", resource: f.object %>
       </div>
       <div class="form-group mb-6">
         <%= f.label :humidity, class: "u-font-size-90" %>
-        <%= f.number_field :humidity, step: "0.1", placeholder: "65.4", class: "form-control" %>
+        <%= f.number_field :humidity, step: "0.1", placeholder: "65.4", value: @humidity, class: "form-control" %>
         <%= render "shared/error_messages/invalid_humidity", resource: f.object %>
       </div>
       <div class="text-center mb-3">

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -7,6 +7,16 @@
     </header>
     <%= form_with model: @log do |f| %>
       <%= render "shared/log_form", f: f %>
+      <div class="form-group mb-4">
+        <%= f.label :temperature, class: "u-font-size-90" %>
+        <%= f.number_field :temperature, step: "0.1", placeholder: "12.3", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_temperature", resource: f.object %>
+      </div>
+      <div class="form-group mb-6">
+        <%= f.label :humidity, class: "u-font-size-90" %>
+        <%= f.number_field :humidity, step: "0.1", placeholder: "65.4", class: "form-control" %>
+        <%= render "shared/error_messages/invalid_humidity", resource: f.object %>
+      </div>
       <div class="text-center mb-3">
         <%= f.submit "ログを追加", class: "btn btn-secondary btn-lg" %>
       </div>

--- a/app/views/shared/_log_form.html.erb
+++ b/app/views/shared/_log_form.html.erb
@@ -36,16 +36,6 @@
   <%= f.text_area :memo, placeholder: "メモ", class: "form-control" %>
   <%= render "shared/error_messages/invalid_memo", resource: f.object %>
 </div>
-<div class="form-group mb-4">
-  <%= f.label :temperature, class: "u-font-size-90" %>
-  <%= f.number_field :temperature, step: "0.1", placeholder: "12.3", class: "form-control" %>
-  <%= render "shared/error_messages/invalid_temperature", resource: f.object %>
-</div>
-<div class="form-group mb-4">
-  <%= f.label :humidity, class: "u-font-size-90" %>
-  <%= f.number_field :humidity, step: "0.1", placeholder: "65.4", class: "form-control" %>
-  <%= render "shared/error_messages/invalid_humidity", resource: f.object %>
-</div>
 <div class="row">
   <div class="col-md-6">
     <div class="form-group mb-4">
@@ -61,7 +51,7 @@
     </div>
   </div>
 </div>
-<div class="form-group mb-6">
+<div class="form-group mb-4">
   <%= f.label :image, class: "u-font-size-90" %>
   <%= f.file_field :image, class: "form-control" %>
   <%= render "shared/error_messages/invalid_image", resource: f.object %>


### PR DESCRIPTION
概要
- `users`テーブルの`latitude`カラム、`longitude`カラムに値が保存されている場合、OpenWeatherが提供している下記APIを叩いて現在の気温と湿度を取得する
  - https://openweathermap.org/current#one
- 気象情報の取得に成功した場合は、新規ログ作成時のフォームの`temperature`カラムと`humidity`カラムの入力欄が補完された状態で表示する
- 位置情報を登録しているが、気象情報の取得に失敗した場合はその旨をフラッシュメッセージで表示
- ユーザー設定画面から位置情報(郵便番号)を登録していない場合はフォームの入力欄のみを表示