### PR TITLE
[Votalog] マイ多肉棚のALLボタンのレイアウトを調整

### DIFF
--- a/app/views/shared/_my_shelf.html.erb
+++ b/app/views/shared/_my_shelf.html.erb
@@ -1,17 +1,20 @@
 <section class="u-content-space">
   <div class="container my-shelf">
-    <header class="w-md50 mx-auto mb-2">
+    <header class="w-md50 mx-auto mb-4">
       <h4>マイ多肉棚</h4>
     </header>
-    <div class="mb-6 text-right">
-      <%= link_to new_plant_path, class: "btn btn-outline-info" do %>
-        新しい株を追加する<i class="fas fa-plus-circle ml-2"></i>
-      <% end %>
-    </div>
-    <div class="row mb-2">
-      <div class="col-lg-4 col-md-6 text-center mb-3">
-        <%= link_to "ALL", root_path, class: "btn btn-outline-secondary" %>
+    <div class="row mb-4">
+      <div class="col-md-6 text-center">
+        <%= link_to "お世話スケジュール(全体)", root_path, class: "btn btn-outline-info" %>
       </div>
+      <div class="col-md-6 text-center">
+        <%= link_to new_plant_path, class: "btn btn-outline-info" do %>
+          新しい株を追加する<i class="fas fa-plus-circle ml-2"></i>
+        <% end %>
+      </div>
+    </div>
+    <hr class="mb-4">
+    <div class="row">
       <% resources.each do |resource| %>
         <div class="col-lg-4 col-md-6 text-center mb-3">
           <%= link_to plant_path(resource), class: "btn btn-outline-secondary" do %>

--- a/spec/system/plants_spec.rb
+++ b/spec/system/plants_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "Plants", type: :system do
 
     context "ALLボタンを押下した場合" do
       it "お世話スケジュール画面に遷移すること" do
-        click_on "ALL"
+        click_on "お世話スケジュール"
         expect(current_path).to eq root_path
       end
     end


### PR DESCRIPTION
概要
- 「マイ多肉棚」のALLボタンと個別の株名称のボタンの配置と色使いを調整
  - ALLボタンが株名称ボタンと同化しないよう調整を行いました
- `ALL`ボタンの文言を`お世話スケジュール（全体）`に変更
  - ボタンを押したときの挙動をユーザーが予想しやすくするため文言を修正しました
  - 文言修正に追随するためPlantのシステムスペックでクリックする要素を修正しました
- `rspec`でテストが通ることを確認
![スクリーンショット 2024-01-04 18 50 23](https://github.com/suiys/votalog/assets/132334832/a7a7534c-831f-4b93-9732-a663585dd7cc)
- `bundle exec rubocop --require rubocop-airbnb` でoffenseが検出されないことを確認
![スクリーンショット 2024-01-04 19 04 03](https://github.com/suiys/votalog/assets/132334832/809298f1-daa4-458c-ab99-318ac15c970a)

