### PR TITLE
[Votalog] 個別株詳細画面の見出し修正

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header class="w-md50 mx-auto text-center mb-6">
+    <header class="w-md-50 mx-auto text-center mb-6">
       <h2>アカウント情報編集</h2>
     </header>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header class="w-md50 mx-auto text-center mb-6">
+    <header class="w-md-50 mx-auto text-center mb-6">
       <h2>新規登録</h2>
     </header>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header class="w-md50 mx-auto text-center mb-6">
+    <header class="w-md-50 mx-auto text-center mb-6">
       <h2>ログイン</h2>
     </header>
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <% if user_signed_in? %>
   <section class="u-content-space">
     <div class="container">
-      <header class="w-md50 mx-automb-6 mb-4 d-flex justify-content-between align-items-center">
+      <header class="w-md-50 mx-auto mb-6 text-center">
         <h2 class="mb-0">お世話スケジュール</h2>
       </header>
       <div class="row mb-6">

--- a/app/views/logs/edit.html.erb
+++ b/app/views/logs/edit.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header class="w-md50 mx-auto text-center mb-6">
+    <header class="w-md-50 mx-auto text-center mb-6">
       <h2>ログ編集</h2>
     </header>
     <%= form_with model: @log do |f| %>

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header class="w-md50 mx-auto text-center mb-6">
+    <header class="w-md-50 mx-auto text-center mb-6">
       <h2>新規ログ追加</h2>
     </header>
     <%= form_with model: @log do |f| %>

--- a/app/views/logs/show.html.erb
+++ b/app/views/logs/show.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header class="w-md50 mx-auto text-center mb-6">
+    <header class="w-md-50 mx-auto text-center mb-6">
       <h2>
         <%= @log.start_time.strftime("%Y/%m/%d") %> の
         <%= @log.plant.name %> ログ

--- a/app/views/plants/edit.html.erb
+++ b/app/views/plants/edit.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header  class="w-md50 mx-auto text-center mb-6">
+    <header  class="w-md-50 mx-auto text-center mb-6">
       <h2>株情報編集</h2>
     </header>
     <%= form_with model: @plant do |f| %>

--- a/app/views/plants/new.html.erb
+++ b/app/views/plants/new.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header  class="w-md50 mx-auto text-center mb-6">
+    <header  class="w-md-50 mx-auto text-center mb-6">
       <h2>新規株登録</h2>
     </header>
     <%= form_with model: @plant do |f| %>

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -40,6 +40,9 @@
       </p>
       <p class="pl-2">カレンダー上の各アイコンをクリックすると該当するログにジャンプして詳細を確認できます</p>
     </div>
+    <h4 class="w-md-50 mx-auto mb-2 text-center">
+      次回お世話予定 | <%= @plant.name %>
+    </h4>
     <div class="row mb-6">
       <div class="col-md-4 text-center bg-light p-3 next-water-schedule">
         <p>次回水やり予定日</p>

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header class="w-md50 mx-automb-6 mb-4 d-flex justify-content-between align-items-center">
+    <header class="w-md-50 mx-auto mb-6 d-flex justify-content-between align-items-center">
       <h2 class="mb-0">お世話ログ for <%= @plant.name %></h2>
       <div>
         <% if @plant.image.attached? %>

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -87,7 +87,7 @@
   </div>
 </section>
 
-<%= render  "shared/my_shelf", resources: @user.plants %>
+<%= render "shared/my_shelf", resources: @user.plants %>
 
 <div class="modal fade" id="nextDayModal" tabindex="-1" role="dialog" area-labelledby="nextDayTitle" style="display: none;" area-hidden="true">
   <div class="modal-dialog modal-dialog-centered" role="document">

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -4,12 +4,12 @@
   <div class="container">
     <% if @plant.image.attached? %>
       <header class="w-md-50 mx-auto mb-6 d-flex justify-content-between align-items-center">
-        <h2 class="mb-0">お世話ログ for <%= @plant.name %></h2>
+        <h2 class="mb-0">お世話ログ | <%= @plant.name %></h2>
         <%= image_tag @plant.image.variant(resize: "72", gravity: "center", crop: "48x48+0+0").processed, class: "u-box-shadow-lg img-fluid rounded-circle", alt: "株イメージ画像" %>
       </header>
     <% else %>
       <header class="w-md-50 mx-auto mb-6 text-center">
-        <h2 class="mb-0">お世話ログ for <%= @plant.name %></h2>
+        <h2 class="mb-0">お世話ログ | <%= @plant.name %></h2>
       </header>
     <% end %>
     <div class="mb-6">

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -2,14 +2,16 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header class="w-md-50 mx-auto mb-6 d-flex justify-content-between align-items-center">
-      <h2 class="mb-0">お世話ログ for <%= @plant.name %></h2>
-      <div>
-        <% if @plant.image.attached? %>
-          <%= image_tag @plant.image.variant(resize: "72", gravity: "center", crop: "72x72+0+0").processed, class: "u-box-shadow-lg img-fluid rounded-circle", alt: "株イメージ画像" %>
-        <% end %>
-      </div>
-    </header>
+    <% if @plant.image.attached? %>
+      <header class="w-md-50 mx-auto mb-6 d-flex justify-content-between align-items-center">
+        <h2 class="mb-0">お世話ログ for <%= @plant.name %></h2>
+        <%= image_tag @plant.image.variant(resize: "72", gravity: "center", crop: "48x48+0+0").processed, class: "u-box-shadow-lg img-fluid rounded-circle", alt: "株イメージ画像" %>
+      </header>
+    <% else %>
+      <header class="w-md-50 mx-auto mb-6 text-center">
+        <h2 class="mb-0">お世話ログ for <%= @plant.name %></h2>
+      </header>
+    <% end %>
     <div class="mb-6">
       <%= month_calendar events: @plant.logs do |date, logs| %>
         <%= date.day %>

--- a/app/views/shared/_my_shelf.html.erb
+++ b/app/views/shared/_my_shelf.html.erb
@@ -1,6 +1,6 @@
 <section class="u-content-space">
   <div class="container my-shelf">
-    <header class="w-md50 mx-auto mb-4">
+    <header class="w-md-50 mx-auto mb-4">
       <h4>マイ多肉棚</h4>
     </header>
     <div class="row mb-4">

--- a/app/views/shared/_my_shelf.html.erb
+++ b/app/views/shared/_my_shelf.html.erb
@@ -1,6 +1,6 @@
 <section class="u-content-space">
   <div class="container my-shelf">
-    <header class="w-md-50 mx-auto mb-4">
+    <header class="w-md-50 mx-auto mb-4 text-center">
       <h4>マイ多肉棚</h4>
     </header>
     <div class="row mb-4">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header class="w-md50 mx-auto text-center mb-6">
+    <header class="w-md-50 mx-auto text-center mb-6">
       <h2>ユーザー設定編集</h2>
     </header>
     <%= form_with model: @user do |f| %>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header class="w-md50 mx-auto text-center mb-6">
+    <header class="w-md-50 mx-auto text-center mb-6">
       <h2>ユーザー設定</h2>
     </header>
     <div class="row mb-2">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
 
 <section class="u-content-space">
   <div class="container">
-    <header class="w-md50 mx-auto text-center mb-6">
+    <header class="w-md-50 mx-auto text-center mb-6">
       <h2>アカウント情報</h2>
     </header>
     <div class="row mb-2">

--- a/spec/system/plants_spec.rb
+++ b/spec/system/plants_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Plants", type: :system do
         new_plant = build(:plant, name: "testplant")
         fill_in "株名称", with: new_plant.name
         click_on "マイ多肉棚に追加"
-        expect(page).to have_content "お世話ログ for #{new_plant.name}"
+        expect(page).to have_content "お世話ログ | #{new_plant.name}"
         expect(page).to have_content "#{new_plant.name}をマイ多肉棚に追加しました"
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe "Plants", type: :system do
     end
 
     it "ページ見出しに対象の株名称と株画像が表示されること" do
-      expect(page).to have_content "お世話ログ for #{plant_with_png_image.name}"
+      expect(page).to have_content "お世話ログ | #{plant_with_png_image.name}"
       expect(page).to have_selector "img[alt=株イメージ画像]"
     end
 


### PR DESCRIPTION
概要
- 次回水やり予定日等の一覧の上部に、対象の株名称を表示するタイトル部分を追加
- クラス名のタイポによりbootstrapの意図したスタイルが当たっていなかった`header`のクラス名を修正
- 株画像の登録有無に応じて`header`に適用するスタイルを変更し、タイトルが中央揃えになるよう調整
- お世話ログおよび次回お世話予定の見出しと株名称を`|`でつなぐよう統一し、システムスペックにも変更を反映
- `rspec`でテストが通ることを確認
![スクリーンショット 2024-01-05 12 28 46](https://github.com/suiys/votalog/assets/132334832/39db1c39-9a77-47ab-ad62-f20d8f8a5837)
- `bundle exec rubocop --require rubocop-airbnb`でoffenseが検出されないことを確認
![スクリーンショット 2024-01-05 12 29 17](https://github.com/suiys/votalog/assets/132334832/60414fda-9180-4322-88b9-bf486fc1413c)
