### PR TITLE
[Votalog] 明日のお世話スケジュール表示機能を明日以降のスケジュール表示機能にアップデート

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,13 +1,15 @@
 class HomeController < ApplicationController
+  MAX_RESULT_COUNT = 5
+
   def index
     if user_signed_in?
       @user = current_user
       @todays_water_scheduled_plants = Plant.search_todays_schedules(@user, "water")
       @todays_fertilizer_scheduled_plants = Plant.search_todays_schedules(@user, "fertilizer")
       @todays_replant_scheduled_plants = Plant.search_todays_schedules(@user, "replant")
-      @tomorrows_water_scheduled_plants = Plant.search_tomorrows_schedules(@user, "water")
-      @tomorrows_fertilizer_scheduled_plants = Plant.search_tomorrows_schedules(@user, "fertilizer")
-      @tomorrows_replant_scheduled_plants = Plant.search_tomorrows_schedules(@user, "replant")
+      @future_water_scheduled_plants = Plant.search_future_schedules(@user, "water").limit(MAX_RESULT_COUNT)
+      @future_fertilizer_scheduled_plants = Plant.search_future_schedules(@user, "fertilizer").limit(MAX_RESULT_COUNT)
+      @future_replant_scheduled_plants = Plant.search_future_schedules(@user, "replant").limit(MAX_RESULT_COUNT)
     end
   end
 end

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -20,7 +20,7 @@ class Plant < ApplicationRecord
     Plant.where("user_id = ? and next_#{params}_day = ?", user.id, Time.zone.today) # rubocop:disable Airbnb/RiskyActiverecordInvocation
   end
 
-  def self.search_tomorrows_schedules(user, params)
-    Plant.where("user_id = ? and next_#{params}_day = ?", user.id, Time.zone.tomorrow) # rubocop:disable Airbnb/RiskyActiverecordInvocation
+  def self.search_future_schedules(user, params)
+    Plant.where("user_id = ? and next_#{params}_day >= ?", user.id, Time.zone.tomorrow).order("next_#{params}_day") # rubocop:disable Airbnb/RiskyActiverecordInvocation
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -22,17 +22,17 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-md-4 text-center bg-light p-3 tomorrows-water-schedule">
+        <div class="col-md-4 text-center bg-light p-3 future-water-schedule">
           <p>明日以降水やり予定の株</p>
           <hr class="mb-4">
           <%= render "shared/future_water_schedule", schedules: @future_water_scheduled_plants %>
         </div>
-        <div class="col-md-4 text-center bg-light p-3 tomorrows-fertilizer-schedule">
+        <div class="col-md-4 text-center bg-light p-3 future-fertilizer-schedule">
           <p>明日以降肥料/栄養剤散布予定の株</p>
           <hr class="mb-4">
           <%= render "shared/future_fertilizer_schedule", schedules: @future_fertilizer_scheduled_plants %>
         </div>
-        <div class="col-md-4 text-center bg-light p-3 tomorrows-replant-schedule">
+        <div class="col-md-4 text-center bg-light p-3 future-replant-schedule">
           <p>明日以降植替え予定の株</p>
           <hr class="mb-4">
           <%= render "shared/future_replant_schedule", schedules: @future_replant_scheduled_plants %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -23,21 +23,22 @@
       </div>
       <div class="row">
         <div class="col-md-4 text-center bg-light p-3 tomorrows-water-schedule">
-          <p>明日水やり予定の株</p>
+          <p>明日以降水やり予定の株</p>
           <hr class="mb-4">
-          <%= render "shared/schedule_list", schedules: @tomorrows_water_scheduled_plants %>
+          <%= render "shared/future_water_schedule", schedules: @future_water_scheduled_plants %>
         </div>
         <div class="col-md-4 text-center bg-light p-3 tomorrows-fertilizer-schedule">
-          <p>明日肥料/栄養剤散布予定の株</p>
+          <p>明日以降肥料/栄養剤散布予定の株</p>
           <hr class="mb-4">
-          <%= render "shared/schedule_list", schedules: @tomorrows_fertilizer_scheduled_plants %>
+          <%= render "shared/future_fertilizer_schedule", schedules: @future_fertilizer_scheduled_plants %>
         </div>
         <div class="col-md-4 text-center bg-light p-3 tomorrows-replant-schedule">
-          <p>明日植替え予定の株</p>
+          <p>明日以降植替え予定の株</p>
           <hr class="mb-4">
-          <%= render "shared/schedule_list", schedules: @tomorrows_replant_scheduled_plants %>
+          <%= render "shared/future_replant_schedule", schedules: @future_replant_scheduled_plants %>
         </div>
       </div>
+      <p>※ 明日以降のお世話スケジュールは直近の予定を最大5つまで表示します</p>
     </div>
   </section>
   <%= render "shared/my_shelf", resources: @user.plants %>

--- a/app/views/shared/_future_fertilizer_schedule.html.erb
+++ b/app/views/shared/_future_fertilizer_schedule.html.erb
@@ -1,0 +1,14 @@
+<div>
+  <% if schedules.present? %>
+    <% schedules.each do |plant| %>
+      <p class="mb-2">
+        <%= link_to plant_path(plant) do %>
+          <%= plant.name %>
+          (<%= plant.next_fertilizer_day.strftime("%Y/%m/%d") %>)
+        <% end %>
+      </p>
+    <% end %>
+  <% else %>
+    <p class="mb-2">なし</p>
+  <% end %>
+</div>

--- a/app/views/shared/_future_replant_schedule.html.erb
+++ b/app/views/shared/_future_replant_schedule.html.erb
@@ -1,0 +1,14 @@
+<div>
+  <% if schedules.present? %>
+    <% schedules.each do |plant| %>
+      <p class="mb-2">
+        <%= link_to plant_path(plant) do %>
+          <%= plant.name %>
+          (<%= plant.next_replant_day.strftime("%Y/%m/%d") %>)
+        <% end %>
+      </p>
+    <% end %>
+  <% else %>
+    <p class="mb-2">なし</p>
+  <% end %>
+</div>

--- a/app/views/shared/_future_water_schedule.html.erb
+++ b/app/views/shared/_future_water_schedule.html.erb
@@ -1,0 +1,14 @@
+<div>
+  <% if schedules.present? %>
+    <% schedules.each do |plant| %>
+      <p class="mb-2">
+        <%= link_to plant_path(plant) do %>
+          <%= plant.name %>
+          (<%= plant.next_water_day.strftime("%Y/%m/%d") %>)
+        <% end %>
+      </p>
+    <% end %>
+  <% else %>
+    <p class="mb-2">なし</p>
+  <% end %>
+</div>

--- a/spec/models/plant_spec.rb
+++ b/spec/models/plant_spec.rb
@@ -59,9 +59,13 @@ RSpec.describe Plant, type: :model do
     end
   end
 
-  describe ".search_tomorrows_schedules" do
-    let!(:target_plant_to_water_tomorrow) do
-      create_list(:plant, 2, next_water_day: Time.zone.tomorrow, user: user)
+  describe ".search_future_schedules" do
+    let!(:target_plant_to_water_future) do
+      [
+        create(:plant, next_water_day: Time.zone.tomorrow, user: user),
+        create(:plant, next_water_day: Time.zone.tomorrow + 1.day, user: user),
+        create(:plant, next_water_day: Time.zone.tomorrow + 2.day, user: user),
+      ]
     end
     let!(:not_target_user_plant_to_water_tomorrow) do
       create(:plant, next_water_day: Time.zone.tomorrow, user: another_user)
@@ -69,15 +73,15 @@ RSpec.describe Plant, type: :model do
     let!(:not_target_date_plant_to_water) do
       create(:plant, next_water_day: Time.zone.today, user: user)
     end
-    let!(:plant_to_fertilize_today) do
+    let!(:plant_to_fertilize_tomorrow) do
       create(:plant, next_fertilizer_day: Time.zone.tomorrow, user: user)
     end
-    let!(:plant_to_replant_today) do
+    let!(:plant_to_replant_tomorrow) do
       create(:plant, next_replant_day: Time.zone.tomorrow, user: user)
     end
 
-    it "明日水やり予定の株が全て抽出できていること" do
-      expect(Plant.search_tomorrows_schedules(user, "water")).to match_array target_plant_to_water_tomorrow
+    it "明日以降水やり予定の株が過不足なく抽出できていること" do
+      expect(Plant.search_future_schedules(user, "water")).to match_array target_plant_to_water_future
     end
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -379,18 +379,21 @@ RSpec.describe "Users", type: :system do
       end
     end
 
-    it "明日肥料/栄養剤散布予定の株に名称が表示され、押下すると株詳細画面に遷移すること" do
-      within ".tomorrows-fertilizer-schedule" do
+    it "明日以降肥料/栄養剤散布予定の株に名称と日付が表示され、押下すると株詳細画面に遷移すること" do
+      within ".future-fertilizer-schedule" do
         expect(page).to have_content plant2.name
+        expect(page).to have_content plant2.next_fertilizer_day.strftime("%Y/%m/%d")
         click_on plant2.name
         expect(current_path).to eq plant_path(plant2)
       end
     end
 
-    it "明日植替え予定の株に名称が表示され、押下すると株詳細画面に遷移すること" do
-      within ".tomorrows-replant-schedule" do
+    it "明日以降植替え予定の株に名称と日付が表示され、押下すると株詳細画面に遷移すること" do
+      within ".future-replant-schedule" do
         expect(page).to have_content plant1.name
+        expect(page).to have_content plant1.next_replant_day.strftime("%Y/%m/%d")
         expect(page).to have_content plant2.name
+        expect(page).to have_content plant2.next_replant_day.strftime("%Y/%m/%d")
         click_on plant1.name
         expect(current_path).to eq plant_path(plant1)
         visit root_path
@@ -406,7 +409,7 @@ RSpec.describe "Users", type: :system do
       within ".todays-replant-schedule" do
         expect(page).to have_content "なし"
       end
-      within ".tomorrows-water-schedule" do
+      within ".future-water-schedule" do
         expect(page).to have_content "なし"
       end
     end


### PR DESCRIPTION
概要
- UX向上のため、明日のお世話スケジュール表示機能の仕様を下記の通りアップデート
  - 明日以降の水やり・肥料/栄養剤散布・植替え予定をそれぞれ昇順（近い予定順）で最大5件まで表示
    - 今日のスケジュールは全件表示する必要があると考えるものの、明日以降のスケジュールは全て表示されていると情報量が多くなりすぎてしまう懸念があるため最大表示件数を設けました
  - 明日以外のお世話予定も表示するようになったため、お世話予定日を株名称の後にそれぞれ表示
- 明日以降のお世話スケジュール表示機能へのアップデートに伴い対応するテストに変更を反映
- `rspec`でテストが通ることを確認
![スクリーンショット 2024-01-18 2 28 27](https://github.com/suiys/votalog/assets/132334832/6614d0ac-df73-42f1-9d60-42ec9335e7ef)
- `bundle exec rubocop --require rubocop-airbnb`でoffenseが検出されないことを確認
![スクリーンショット 2024-01-18 2 28 52](https://github.com/suiys/votalog/assets/132334832/7ce28e71-fab3-459b-a2b4-23783b64e629)
