### PR TITLE
[Votalog] 次回お世話予定のクリア方法の説明を追加

### DIFF
--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -30,7 +30,7 @@
     <header class="w-md-50 mx-auto mb-6 text-center">
       <h3 class="mb-0">次回お世話予定 | <%= @plant.name %></h3>
     </header>
-    <div class="row mb-6">
+    <div class="row mb-3">
       <div class="col-md-4 text-center bg-light p-3 next-water-schedule">
         <p>次回水やり予定日</p>
         <hr class="mb-6">
@@ -58,6 +58,7 @@
         </div>
       </div>
     </div>
+    <p>※ 予定を削除するには、「お世話予定を追加/変更」> 削除したい予定のカレンダーアイコンをクリック > カレンダー左下の「削除」>「決定」を選択</p>
   </div>
 </section>
 


### PR DESCRIPTION
概要
- 設定済みの次回お世話予定をクリアする方法がユーザーに伝わりやすいよう説明を追加しました
- `rspec`でテストが通ることを確認
![スクリーンショット 2024-01-22 23 47 26](https://github.com/suiys/votalog/assets/132334832/69f66d3d-368d-4ad9-8c29-b7d4c8bf9778)
- `bundle exec rubocop --require rubocop-airbnb`でoffenseが検出されないことを確認
![スクリーンショット 2024-01-22 23 47 49](https://github.com/suiys/votalog/assets/132334832/969dd3fe-eace-45e9-b749-ab18dbb18cc0)
